### PR TITLE
Add content read permission to github test workflow

### DIFF
--- a/.github/workflows/test-python-package.yml
+++ b/.github/workflows/test-python-package.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ThyMYthOS/python-stiebel-eltron/security/code-scanning/1](https://github.com/ThyMYthOS/python-stiebel-eltron/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify `contents: read`, which is sufficient for the workflow's operations (e.g., checking out the repository and running tests). This change ensures that the workflow adheres to the principle of least privilege by explicitly limiting the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
