### PR TITLE
Adapt library to pymodbus 3.10.0

### DIFF
--- a/example.py
+++ b/example.py
@@ -5,7 +5,7 @@ from pymodbus.client import ModbusTcpClient as ModbusClient
 
 host_ip = "192.168.1.20"
 host_port = 502
-slave = 1
+device_id = 1
 
 def test_function(mod, fun):
     """Executes the given function on the Stiebel Heatpump and prints the result."""
@@ -45,7 +45,7 @@ def main():
                           timeout=2)
     client.connect()
 
-    unit = pyse.StiebelEltronAPI(client, slave)
+    unit = pyse.StiebelEltronAPI(client, device_id)
     unit.update()
 
     execute_tests(unit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "pymodbus>=3.8.3",
+    "pymodbus>=3.10.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<3.14"
 dependencies = [
-    "pymodbus>=3.10.0",
+    "pymodbus (>=3.10.0,<4)",
 ]
 
 [build-system]

--- a/pystiebeleltron/lwz.py
+++ b/pystiebeleltron/lwz.py
@@ -349,7 +349,7 @@ class OperatingMode(Enum):
 
 
 class LwzStiebelEltronAPI(StiebelEltronAPI):
-    def __init__(self, host: str, port: int = 502, slave: int = 1) -> None:
+    def __init__(self, host: str, port: int = 502, device_id: int = 1) -> None:
         super().__init__(
             [
                 ModbusRegisterBlock(base_address=0, count=34, name="System Values", registers=LWZ_SYSTEM_VALUES_REGISTERS, register_type=RegisterType.INPUT_REGISTER),
@@ -361,7 +361,7 @@ class LwzStiebelEltronAPI(StiebelEltronAPI):
             ],
             host,
             port,
-            slave,
+            device_id,
         )
 
     async def async_update(self):

--- a/pystiebeleltron/pystiebeleltron.py
+++ b/pystiebeleltron/pystiebeleltron.py
@@ -33,39 +33,39 @@ B1_START_ADDR = 0
 
 B1_REGMAP_INPUT = {
     # HC = Heating Circuit
-    "ACTUAL_ROOM_TEMPERATURE_HC1": {"addr": 0, "type": 2, "value": 0},
-    "SET_ROOM_TEMPERATURE_HC1": {"addr": 1, "type": 2, "value": 0},
-    "RELATIVE_HUMIDITY_HC1": {"addr": 2, "type": 2, "value": 0},
-    "ACTUAL_ROOM_TEMPERATURE_HC2": {"addr": 3, "type": 2, "value": 0},
-    "SET_ROOM_TEMPERATURE_HC2": {"addr": 4, "type": 2, "value": 0},
-    "RELATIVE_HUMIDITY_HC2": {"addr": 5, "type": 2, "value": 0},
-    "OUTSIDE_TEMPERATURE": {"addr": 6, "type": 2, "value": 0},
-    "ACTUAL_VALUE_HC1": {"addr": 7, "type": 2, "value": 0},
-    "SET_VALUE_HC1": {"addr": 8, "type": 2, "value": 0},
-    "ACTUAL_VALUE_HC2": {"addr": 9, "type": 2, "value": 0},
-    "SET_VALUE_HC2": {"addr": 10, "type": 2, "value": 0},
-    "FLOW_TEMPERATURE": {"addr": 11, "type": 2, "value": 0},
-    "RETURN_TEMPERATURE": {"addr": 12, "type": 2, "value": 0},
-    "PRESSURE_HEATING_CIRCUIT": {"addr": 13, "type": 2, "value": 0},
-    "FLOW_RATE": {"addr": 14, "type": 2, "value": 0},
-    "ACTUAL_DHW_TEMPERATURE": {"addr": 15, "type": 2, "value": 0},
-    "SET_DHW_TEMPERATURE": {"addr": 16, "type": 2, "value": 0},
-    "VENTILATION_AIR_ACTUAL_FAN_SPEED": {"addr": 17, "type": 6, "value": 0},
-    "VENTILATION_AIR_SET_FLOW_RATE": {"addr": 18, "type": 6, "value": 0},
-    "EXTRACT_AIR_ACTUAL_FAN_SPEED": {"addr": 19, "type": 6, "value": 0},
-    "EXTRACT_AIR_SET_FLOW_RATE": {"addr": 20, "type": 6, "value": 0},
-    "EXTRACT_AIR_HUMIDITY": {"addr": 21, "type": 6, "value": 0},
-    "EXTRACT_AIR_TEMPERATURE": {"addr": 22, "type": 2, "value": 0},
-    "EXTRACT_AIR_DEW_POINT": {"addr": 23, "type": 2, "value": 0},
-    "DEW_POINT_TEMPERATUR_HC1": {"addr": 24, "type": 2, "value": 0},
-    "DEW_POINT_TEMPERATUR_HC2": {"addr": 25, "type": 2, "value": 0},
-    "COLLECTOR_TEMPERATURE": {"addr": 26, "type": 2, "value": 0},
-    "HOT_GAS_TEMPERATURE": {"addr": 27, "type": 2, "value": 0},
-    "HIGH_PRESSURE": {"addr": 28, "type": 7, "value": 0},
-    "LOW_PRESSURE": {"addr": 29, "type": 7, "value": 0},
-    "COMPRESSOR_STARTS": {"addr": 30, "type": 6, "value": 0},
-    "COMPRESSOR_SPEED": {"addr": 31, "type": 2, "value": 0},
-    "MIXED_WATER_AMOUNT": {"addr": 32, "type": 6, "value": 0},
+    'ACTUAL_ROOM_TEMPERATURE_HC1':      {'addr':  0, 'type': 2, 'value': 0},
+    'SET_ROOM_TEMPERATURE_HC1':         {'addr':  1, 'type': 2, 'value': 0},
+    'RELATIVE_HUMIDITY_HC1':            {'addr':  2, 'type': 2, 'value': 0},
+    'ACTUAL_ROOM_TEMPERATURE_HC2':      {'addr':  3, 'type': 2, 'value': 0},
+    'SET_ROOM_TEMPERATURE_HC2':         {'addr':  4, 'type': 2, 'value': 0},
+    'RELATIVE_HUMIDITY_HC2':            {'addr':  5, 'type': 2, 'value': 0},
+    'OUTSIDE_TEMPERATURE':              {'addr':  6, 'type': 2, 'value': 0},
+    'ACTUAL_VALUE_HC1':                 {'addr':  7, 'type': 2, 'value': 0},
+    'SET_VALUE_HC1':                    {'addr':  8, 'type': 2, 'value': 0},
+    'ACTUAL_VALUE_HC2':                 {'addr':  9, 'type': 2, 'value': 0},
+    'SET_VALUE_HC2':                    {'addr': 10, 'type': 2, 'value': 0},
+    'FLOW_TEMPERATURE':                 {'addr': 11, 'type': 2, 'value': 0},
+    'RETURN_TEMPERATURE':               {'addr': 12, 'type': 2, 'value': 0},
+    'PRESSURE_HEATING_CIRCUIT':         {'addr': 13, 'type': 2, 'value': 0},
+    'FLOW_RATE':                        {'addr': 14, 'type': 2, 'value': 0},
+    'ACTUAL_DHW_TEMPERATURE':           {'addr': 15, 'type': 2, 'value': 0},
+    'SET_DHW_TEMPERATURE':              {'addr': 16, 'type': 2, 'value': 0},
+    'VENTILATION_AIR_ACTUAL_FAN_SPEED': {'addr': 17, 'type': 6, 'value': 0},
+    'VENTILATION_AIR_SET_FLOW_RATE':    {'addr': 18, 'type': 6, 'value': 0},
+    'EXTRACT_AIR_ACTUAL_FAN_SPEED':     {'addr': 19, 'type': 6, 'value': 0},
+    'EXTRACT_AIR_SET_FLOW_RATE':        {'addr': 20, 'type': 6, 'value': 0},
+    'EXTRACT_AIR_HUMIDITY':             {'addr': 21, 'type': 6, 'value': 0},
+    'EXTRACT_AIR_TEMPERATURE':          {'addr': 22, 'type': 2, 'value': 0},
+    'EXTRACT_AIR_DEW_POINT':            {'addr': 23, 'type': 2, 'value': 0},
+    'DEW_POINT_TEMPERATUR_HC1':         {'addr': 24, 'type': 2, 'value': 0},
+    'DEW_POINT_TEMPERATUR_HC2':         {'addr': 25, 'type': 2, 'value': 0},
+    'COLLECTOR_TEMPERATURE':            {'addr': 26, 'type': 2, 'value': 0},
+    'HOT_GAS_TEMPERATURE':              {'addr': 27, 'type': 2, 'value': 0},
+    'HIGH_PRESSURE':                    {'addr': 28, 'type': 7, 'value': 0},
+    'LOW_PRESSURE':                     {'addr': 29, 'type': 7, 'value': 0},
+    'COMPRESSOR_STARTS':                {'addr': 30, 'type': 6, 'value': 0},
+    'COMPRESSOR_SPEED':                 {'addr': 31, 'type': 2, 'value': 0},
+    'MIXED_WATER_AMOUNT':               {'addr': 32, 'type': 6, 'value': 0}
 }
 
 
@@ -73,87 +73,109 @@ B1_REGMAP_INPUT = {
 B2_START_ADDR = 1000
 
 B2_REGMAP_HOLDING = {
-    "OPERATING_MODE": {"addr": 1000, "type": 8, "value": 0},
-    "ROOM_TEMP_HEAT_DAY_HC1": {"addr": 1001, "type": 2, "value": 0},
-    "ROOM_TEMP_HEAT_NIGHT_HC1": {"addr": 1002, "type": 2, "value": 0},
-    "MANUAL_SET_TEMP_HC1": {"addr": 1003, "type": 2, "value": 0},
-    "ROOM_TEMP_HEAT_DAY_HC2": {"addr": 1004, "type": 2, "value": 0},
-    "ROOM_TEMP_HEAT_NIGHT_HC2": {"addr": 1005, "type": 2, "value": 0},
-    "MANUAL_SET_TEAMP_HC2": {"addr": 1006, "type": 2, "value": 0},
-    "GRADIENT_HC1": {"addr": 1007, "type": 7, "value": 0},
-    "LOW_END_HC1": {"addr": 1008, "type": 2, "value": 0},
-    "GRADIENT_HC2": {"addr": 1009, "type": 7, "value": 0},
-    "LOW_END_HC2": {"addr": 1010, "type": 2, "value": 0},
-    "DHW_TEMP_SET_DAY": {"addr": 1011, "type": 2, "value": 0},
-    "DHW_TEMP_SET_NIGHT": {"addr": 1012, "type": 2, "value": 0},
-    "DHW_TEMP_SET_MANUAL": {"addr": 1013, "type": 2, "value": 0},
-    "MWM_SET_DAY": {"addr": 1014, "type": 6, "value": 0},
-    "MWM_SET_NIGHT": {"addr": 1015, "type": 6, "value": 0},
-    "MWM_SET_MANUAL": {"addr": 1016, "type": 6, "value": 0},
-    "DAY_STAGE": {"addr": 1017, "type": 6, "value": 0},
-    "NIGHT_STAGE": {"addr": 1018, "type": 6, "value": 0},
-    "PARTY_STAGE": {"addr": 1019, "type": 6, "value": 0},
-    "MANUAL_STAGE": {"addr": 1020, "type": 6, "value": 0},
-    "ROOM_TEMP_COOL_DAY_HC1": {"addr": 1021, "type": 2, "value": 0},
-    "ROOM_TEMP_COOL_NIGHT_HC1": {"addr": 1022, "type": 2, "value": 0},
-    "ROOM_TEMP_COOL_DAY_HC2": {"addr": 1023, "type": 2, "value": 0},
-    "ROOM_TEMP_COOL_NIGHT_HC2": {"addr": 1024, "type": 2, "value": 0},
-    "RESET": {"addr": 1025, "type": 6, "value": 0},
-    "RESTART_ISG": {"addr": 1026, "type": 6, "value": 0},
+    'OPERATING_MODE':           {'addr': 1000, 'type': 8, 'value': 0},
+    'ROOM_TEMP_HEAT_DAY_HC1':   {'addr': 1001, 'type': 2, 'value': 0},
+    'ROOM_TEMP_HEAT_NIGHT_HC1': {'addr': 1002, 'type': 2, 'value': 0},
+    'MANUAL_SET_TEMP_HC1':      {'addr': 1003, 'type': 2, 'value': 0},
+    'ROOM_TEMP_HEAT_DAY_HC2':   {'addr': 1004, 'type': 2, 'value': 0},
+    'ROOM_TEMP_HEAT_NIGHT_HC2': {'addr': 1005, 'type': 2, 'value': 0},
+    'MANUAL_SET_TEAMP_HC2':     {'addr': 1006, 'type': 2, 'value': 0},
+    'GRADIENT_HC1':             {'addr': 1007, 'type': 7, 'value': 0},
+    'LOW_END_HC1':              {'addr': 1008, 'type': 2, 'value': 0},
+    'GRADIENT_HC2':             {'addr': 1009, 'type': 7, 'value': 0},
+    'LOW_END_HC2':              {'addr': 1010, 'type': 2, 'value': 0},
+    'DHW_TEMP_SET_DAY':         {'addr': 1011, 'type': 2, 'value': 0},
+    'DHW_TEMP_SET_NIGHT':       {'addr': 1012, 'type': 2, 'value': 0},
+    'DHW_TEMP_SET_MANUAL':      {'addr': 1013, 'type': 2, 'value': 0},
+    'MWM_SET_DAY':              {'addr': 1014, 'type': 6, 'value': 0},
+    'MWM_SET_NIGHT':            {'addr': 1015, 'type': 6, 'value': 0},
+    'MWM_SET_MANUAL':           {'addr': 1016, 'type': 6, 'value': 0},
+    'DAY_STAGE':                {'addr': 1017, 'type': 6, 'value': 0},
+    'NIGHT_STAGE':              {'addr': 1018, 'type': 6, 'value': 0},
+    'PARTY_STAGE':              {'addr': 1019, 'type': 6, 'value': 0},
+    'MANUAL_STAGE':             {'addr': 1020, 'type': 6, 'value': 0},
+    'ROOM_TEMP_COOL_DAY_HC1':   {'addr': 1021, 'type': 2, 'value': 0},
+    'ROOM_TEMP_COOL_NIGHT_HC1': {'addr': 1022, 'type': 2, 'value': 0},
+    'ROOM_TEMP_COOL_DAY_HC2':   {'addr': 1023, 'type': 2, 'value': 0},
+    'ROOM_TEMP_COOL_NIGHT_HC2': {'addr': 1024, 'type': 2, 'value': 0},
+    'RESET':                    {'addr': 1025, 'type': 6, 'value': 0},
+    'RESTART_ISG':              {'addr': 1026, 'type': 6, 'value': 0}
 }
 
 B2_OPERATING_MODE_READ = {
     # AUTOMATIK
-    11: "AUTOMATIC",
+    11: 'AUTOMATIC',
     # BEREITSCHAFT
-    1: "STANDBY",
+    1: 'STANDBY',
     # TAGBETRIEB
-    3: "DAY MODE",
+    3: 'DAY MODE',
     # ABSENKBETRIEB
-    4: "SETBACK MODE",
+    4: 'SETBACK MODE',
     # WARMWASSER
-    5: "DHW",
+    5: 'DHW',
     # HANDBETRIEB
-    14: "MANUAL MODE",
+    14: 'MANUAL MODE',
     # NOTBETRIEB
-    0: "EMERGENCY OPERATION",
+    0: 'EMERGENCY OPERATION'
 }
 
-B2_OPERATING_MODE_WRITE = {value: key for key, value in B2_OPERATING_MODE_READ.items()}
+B2_OPERATING_MODE_WRITE = {
+    value: key for key, value in B2_OPERATING_MODE_READ.items()
+}
 
-B2_RESET = {"OFF": 0, "ON": 1}
+B2_RESET = {
+    'OFF': 0,
+    'ON': 1
+}
 
-B2_RESTART_ISG = {"OFF": 0, "RESET": 1, "MENU": 2}
+B2_RESTART_ISG = {
+    'OFF': 0,
+    'RESET': 1,
+    'MENU': 2
+}
 
 # Block 3 System status (Read input register) - page 31
 B3_START_ADDR = 2000
 
-B3_REGMAP_INPUT = {"OPERATING_STATUS": {"addr": 2000, "type": 6, "value": 0}, "FAULT_STATUS": {"addr": 2001, "type": 6, "value": 0}, "BUS_STATUS": {"addr": 2002, "type": 6, "value": 0}}
-
-B3_OPERATING_STATUS = {
-    "SWITCHING_PROGRAM_ENABLED": (1 << 0),
-    "COMPRESSOR": (1 << 1),
-    "HEATING": (1 << 2),
-    "COOLING": (1 << 3),
-    "DHW": (1 << 4),
-    "ELECTRIC_REHEATING": (1 << 5),
-    "SERVICE": (1 << 6),
-    "POWER-OFF": (1 << 7),
-    "FILTER": (1 << 8),
-    "VENTILATION": (1 << 9),
-    "HEATING_CIRCUIT_PUMP": (1 << 10),
-    "EVAPORATOR_DEFROST": (1 << 11),
-    "FILTER_EXTRACT_AIR": (1 << 12),
-    "FILTER_VENTILATION_AIR": (1 << 13),
-    "HEAT-UP_PROGRAM": (1 << 14),
+B3_REGMAP_INPUT = {
+    'OPERATING_STATUS': {'addr': 2000, 'type': 6, 'value': 0},
+    'FAULT_STATUS':     {'addr': 2001, 'type': 6, 'value': 0},
+    'BUS_STATUS':       {'addr': 2002, 'type': 6, 'value': 0}
 }
 
-B3_FAULT_STATUS = {"NO_FAULT": 0, "FAULT": 1}
+B3_OPERATING_STATUS = {
+    'SWITCHING_PROGRAM_ENABLED': (1 << 0),
+    'COMPRESSOR': (1 << 1),
+    'HEATING': (1 << 2),
+    'COOLING': (1 << 3),
+    'DHW': (1 << 4),
+    'ELECTRIC_REHEATING': (1 << 5),
+    'SERVICE': (1 << 6),
+    'POWER-OFF': (1 << 7),
+    'FILTER': (1 << 8),
+    'VENTILATION': (1 << 9),
+    'HEATING_CIRCUIT_PUMP': (1 << 10),
+    'EVAPORATOR_DEFROST': (1 << 11),
+    'FILTER_EXTRACT_AIR': (1 << 12),
+    'FILTER_VENTILATION_AIR': (1 << 13),
+    'HEAT-UP_PROGRAM': (1 << 14)
+}
 
-B3_BUS_STATUS = {"STATUS OK": 0, "STATUS ERROR": -1, "ERROR-PASSIVE": -2, "BUS-OFF": -3, "PHYSICAL-ERROR": -4}
+B3_FAULT_STATUS = {
+    'NO_FAULT': 0,
+    'FAULT': 1
+}
+
+B3_BUS_STATUS = {
+    'STATUS OK': 0,
+    'STATUS ERROR': -1,
+    'ERROR-PASSIVE': -2,
+    'BUS-OFF': -3,
+    'PHYSICAL-ERROR': -4
+}
 
 
-class StiebelEltronAPI:
+class StiebelEltronAPI():
     """Stiebel Eltron API."""
 
     def __init__(self, conn: ModbusClientMixin, device_id=1, update_on_read=False):
@@ -169,22 +191,31 @@ class StiebelEltronAPI:
         """Request current values from heat pump."""
         ret = True
         try:
-            block_1_result_input = self._conn.read_input_registers(device_id=self._device_id, address=B1_START_ADDR, count=len(self._block_1_input_regs)).registers
-            block_2_result_holding = self._conn.read_holding_registers(device_id=self._device_id, address=B2_START_ADDR, count=len(self._block_2_holding_regs)).registers
-            block_3_result_input = self._conn.read_input_registers(device_id=self._device_id, address=B3_START_ADDR, count=len(self._block_3_input_regs)).registers
+            block_1_result_input = self._conn.read_input_registers(
+                device_id=self._device_id,
+                address=B1_START_ADDR,
+                count=len(self._block_1_input_regs)).registers
+            block_2_result_holding = self._conn.read_holding_registers(
+                device_id=self._device_id,
+                address=B2_START_ADDR,
+                count=len(self._block_2_holding_regs)).registers
+            block_3_result_input = self._conn.read_input_registers(
+                device_id=self._device_id,
+                address=B3_START_ADDR,
+                count=len(self._block_3_input_regs)).registers
         except AttributeError:
             # The unit does not reply reliably
             ret = False
             print("Modbus read failed")
         else:
             for v in self._block_1_input_regs.values():
-                v["value"] = block_1_result_input[v["addr"] - B1_START_ADDR]
+                v['value'] = block_1_result_input[v['addr'] - B1_START_ADDR]
 
             for v in self._block_2_holding_regs.values():
-                v["value"] = block_2_result_holding[v["addr"] - B2_START_ADDR]
+                v['value'] = block_2_result_holding[v['addr'] - B2_START_ADDR]
 
             for v in self._block_3_input_regs.values():
-                v["value"] = block_3_result_input[v["addr"] - B3_START_ADDR]
+                v['value'] = block_3_result_input[v['addr'] - B3_START_ADDR]
 
         return ret
 
@@ -205,31 +236,31 @@ class StiebelEltronAPI:
         if value_entry is None:
             return None
 
-        if value_entry["type"] == 2:
-            return value_entry["value"] * 0.1
-        if value_entry["type"] == 7:
-            return value_entry["value"] * 0.01
+        if value_entry['type'] == 2:
+            return value_entry['value'] * 0.1
+        if value_entry['type'] == 7:
+            return value_entry['value'] * 0.01
 
-        return value_entry["value"]
+        return value_entry['value']
 
-    #    def get_raw_input_register(self, name):
-    #        """Get raw register value by name."""
-    #        if self._update_on_read:
-    #            self.update()
-    #        return self._block_1_input_regs[name]
+#    def get_raw_input_register(self, name):
+#        """Get raw register value by name."""
+#        if self._update_on_read:
+#            self.update()
+#        return self._block_1_input_regs[name]
 
-    #    def get_raw_holding_register(self, name):
-    #        """Get raw register value by name."""
-    #        if self._update_on_read:
-    #            self.update()
-    #        return self._block_2_holding_regs[name]
+#    def get_raw_holding_register(self, name):
+#        """Get raw register value by name."""
+#        if self._update_on_read:
+#            self.update()
+#        return self._block_2_holding_regs[name]
 
-    #    def set_raw_holding_register(self, name, value):
-    #        """Write to register by name."""
-    #        self._conn.write_register(
-    #            device_id=self._device_id,
-    #            address=(self._holding_regs[name]['addr']),
-    #            value=value)
+#    def set_raw_holding_register(self, name, value):
+#        """Write to register by name."""
+#        self._conn.write_register(
+#            device_id=self._device_id,
+#            address=(self._holding_regs[name]['addr']),
+#            value=value)
 
     # Handle room temperature & humidity
 
@@ -237,23 +268,27 @@ class StiebelEltronAPI:
         """Get the current room temperature."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val("ACTUAL_ROOM_TEMPERATURE_HC1")
+        return self.get_conv_val('ACTUAL_ROOM_TEMPERATURE_HC1')
 
     def get_target_temp(self):
         """Get the target room temperature."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val("ROOM_TEMP_HEAT_DAY_HC1")
+        return self.get_conv_val('ROOM_TEMP_HEAT_DAY_HC1')
 
     def set_target_temp(self, temp: float):
         """Set the target room temperature (day)(HC1)."""
-        self._conn.write_register(device_id=self._device_id, address=(self._block_2_holding_regs["ROOM_TEMP_HEAT_DAY_HC1"]["addr"]), value=round(temp * 10.0))
+        self._conn.write_register(
+            device_id=self._device_id,
+            address=(
+                self._block_2_holding_regs['ROOM_TEMP_HEAT_DAY_HC1']['addr']),
+            value=round(temp * 10.0))
 
     def get_current_humidity(self):
         """Get the current room humidity."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val("RELATIVE_HUMIDITY_HC1")
+        return self.get_conv_val('RELATIVE_HUMIDITY_HC1')
 
     # Handle operation mode
 
@@ -262,12 +297,15 @@ class StiebelEltronAPI:
         if self._update_on_read:
             self.update()
 
-        op_mode = self.get_conv_val("OPERATING_MODE")
-        return B2_OPERATING_MODE_READ.get(op_mode, "UNKNOWN")
+        op_mode = self.get_conv_val('OPERATING_MODE')
+        return B2_OPERATING_MODE_READ.get(op_mode, 'UNKNOWN')
 
     def set_operation(self, mode: str):
         """Set the operation mode."""
-        self._conn.write_register(device_id=self._device_id, address=(self._block_2_holding_regs["OPERATING_MODE"]["addr"]), value=B2_OPERATING_MODE_WRITE.get(mode))
+        self._conn.write_register(
+            device_id=self._device_id,
+            address=(self._block_2_holding_regs['OPERATING_MODE']['addr']),
+            value=B2_OPERATING_MODE_WRITE.get(mode))
 
     # Handle device status
 
@@ -275,18 +313,22 @@ class StiebelEltronAPI:
         """Return heater status."""
         if self._update_on_read:
             self.update()
-        return bool(self.get_conv_val("OPERATING_STATUS") & B3_OPERATING_STATUS["HEATING"])
+        return bool(self.get_conv_val('OPERATING_STATUS') &
+                    B3_OPERATING_STATUS['HEATING'])
 
     def get_cooling_status(self):
         """Cooling status."""
         if self._update_on_read:
             self.update()
-        return bool(self.get_conv_val("OPERATING_STATUS") & B3_OPERATING_STATUS["COOLING"])
+        return bool(self.get_conv_val('OPERATING_STATUS') &
+                    B3_OPERATING_STATUS['COOLING'])
 
     def get_filter_alarm_status(self):
         """Return filter alarm."""
         if self._update_on_read:
             self.update()
 
-        filter_mask = B3_OPERATING_STATUS["FILTER"] | B3_OPERATING_STATUS["FILTER_EXTRACT_AIR"] | B3_OPERATING_STATUS["FILTER_VENTILATION_AIR"]
-        return bool(self.get_conv_val("OPERATING_STATUS") & filter_mask)
+        filter_mask = (B3_OPERATING_STATUS['FILTER'] |
+                       B3_OPERATING_STATUS['FILTER_EXTRACT_AIR'] |
+                       B3_OPERATING_STATUS['FILTER_VENTILATION_AIR'])
+        return bool(self.get_conv_val('OPERATING_STATUS') & filter_mask)

--- a/pystiebeleltron/pystiebeleltron.py
+++ b/pystiebeleltron/pystiebeleltron.py
@@ -178,13 +178,13 @@ B3_BUS_STATUS = {
 class StiebelEltronAPI():
     """Stiebel Eltron API."""
 
-    def __init__(self, conn: ModbusClientMixin, slave=1, update_on_read=False):
+    def __init__(self, conn: ModbusClientMixin, device_id=1, update_on_read=False):
         """Initialize Stiebel Eltron communication."""
         self._conn = conn
         self._block_1_input_regs = B1_REGMAP_INPUT
         self._block_2_holding_regs = B2_REGMAP_HOLDING
         self._block_3_input_regs = B3_REGMAP_INPUT
-        self._slave = slave
+        self._device_id = device_id
         self._update_on_read = update_on_read
 
     def update(self):
@@ -192,15 +192,15 @@ class StiebelEltronAPI():
         ret = True
         try:
             block_1_result_input = self._conn.read_input_registers(
-                slave=self._slave,
+                device_id=self._device_id,
                 address=B1_START_ADDR,
                 count=len(self._block_1_input_regs)).registers
             block_2_result_holding = self._conn.read_holding_registers(
-                slave=self._slave,
+                device_id=self._device_id,
                 address=B2_START_ADDR,
                 count=len(self._block_2_holding_regs)).registers
             block_3_result_input = self._conn.read_input_registers(
-                slave=self._slave,
+                device_id=self._device_id,
                 address=B3_START_ADDR,
                 count=len(self._block_3_input_regs)).registers
         except AttributeError:
@@ -258,7 +258,7 @@ class StiebelEltronAPI():
 #    def set_raw_holding_register(self, name, value):
 #        """Write to register by name."""
 #        self._conn.write_register(
-#            slave=self._slave,
+#            device_id=self._device_id,
 #            address=(self._holding_regs[name]['addr']),
 #            value=value)
 
@@ -279,7 +279,7 @@ class StiebelEltronAPI():
     def set_target_temp(self, temp: float):
         """Set the target room temperature (day)(HC1)."""
         self._conn.write_register(
-            slave=self._slave,
+            device_id=self._device_id,
             address=(
                 self._block_2_holding_regs['ROOM_TEMP_HEAT_DAY_HC1']['addr']),
             value=round(temp * 10.0))
@@ -303,7 +303,7 @@ class StiebelEltronAPI():
     def set_operation(self, mode: str):
         """Set the operation mode."""
         self._conn.write_register(
-            slave=self._slave,
+            device_id=self._device_id,
             address=(self._block_2_holding_regs['OPERATING_MODE']['addr']),
             value=B2_OPERATING_MODE_WRITE.get(mode))
 

--- a/pystiebeleltron/pystiebeleltron.py
+++ b/pystiebeleltron/pystiebeleltron.py
@@ -33,39 +33,39 @@ B1_START_ADDR = 0
 
 B1_REGMAP_INPUT = {
     # HC = Heating Circuit
-    'ACTUAL_ROOM_TEMPERATURE_HC1':      {'addr':  0, 'type': 2, 'value': 0},
-    'SET_ROOM_TEMPERATURE_HC1':         {'addr':  1, 'type': 2, 'value': 0},
-    'RELATIVE_HUMIDITY_HC1':            {'addr':  2, 'type': 2, 'value': 0},
-    'ACTUAL_ROOM_TEMPERATURE_HC2':      {'addr':  3, 'type': 2, 'value': 0},
-    'SET_ROOM_TEMPERATURE_HC2':         {'addr':  4, 'type': 2, 'value': 0},
-    'RELATIVE_HUMIDITY_HC2':            {'addr':  5, 'type': 2, 'value': 0},
-    'OUTSIDE_TEMPERATURE':              {'addr':  6, 'type': 2, 'value': 0},
-    'ACTUAL_VALUE_HC1':                 {'addr':  7, 'type': 2, 'value': 0},
-    'SET_VALUE_HC1':                    {'addr':  8, 'type': 2, 'value': 0},
-    'ACTUAL_VALUE_HC2':                 {'addr':  9, 'type': 2, 'value': 0},
-    'SET_VALUE_HC2':                    {'addr': 10, 'type': 2, 'value': 0},
-    'FLOW_TEMPERATURE':                 {'addr': 11, 'type': 2, 'value': 0},
-    'RETURN_TEMPERATURE':               {'addr': 12, 'type': 2, 'value': 0},
-    'PRESSURE_HEATING_CIRCUIT':         {'addr': 13, 'type': 2, 'value': 0},
-    'FLOW_RATE':                        {'addr': 14, 'type': 2, 'value': 0},
-    'ACTUAL_DHW_TEMPERATURE':           {'addr': 15, 'type': 2, 'value': 0},
-    'SET_DHW_TEMPERATURE':              {'addr': 16, 'type': 2, 'value': 0},
-    'VENTILATION_AIR_ACTUAL_FAN_SPEED': {'addr': 17, 'type': 6, 'value': 0},
-    'VENTILATION_AIR_SET_FLOW_RATE':    {'addr': 18, 'type': 6, 'value': 0},
-    'EXTRACT_AIR_ACTUAL_FAN_SPEED':     {'addr': 19, 'type': 6, 'value': 0},
-    'EXTRACT_AIR_SET_FLOW_RATE':        {'addr': 20, 'type': 6, 'value': 0},
-    'EXTRACT_AIR_HUMIDITY':             {'addr': 21, 'type': 6, 'value': 0},
-    'EXTRACT_AIR_TEMPERATURE':          {'addr': 22, 'type': 2, 'value': 0},
-    'EXTRACT_AIR_DEW_POINT':            {'addr': 23, 'type': 2, 'value': 0},
-    'DEW_POINT_TEMPERATUR_HC1':         {'addr': 24, 'type': 2, 'value': 0},
-    'DEW_POINT_TEMPERATUR_HC2':         {'addr': 25, 'type': 2, 'value': 0},
-    'COLLECTOR_TEMPERATURE':            {'addr': 26, 'type': 2, 'value': 0},
-    'HOT_GAS_TEMPERATURE':              {'addr': 27, 'type': 2, 'value': 0},
-    'HIGH_PRESSURE':                    {'addr': 28, 'type': 7, 'value': 0},
-    'LOW_PRESSURE':                     {'addr': 29, 'type': 7, 'value': 0},
-    'COMPRESSOR_STARTS':                {'addr': 30, 'type': 6, 'value': 0},
-    'COMPRESSOR_SPEED':                 {'addr': 31, 'type': 2, 'value': 0},
-    'MIXED_WATER_AMOUNT':               {'addr': 32, 'type': 6, 'value': 0}
+    "ACTUAL_ROOM_TEMPERATURE_HC1": {"addr": 0, "type": 2, "value": 0},
+    "SET_ROOM_TEMPERATURE_HC1": {"addr": 1, "type": 2, "value": 0},
+    "RELATIVE_HUMIDITY_HC1": {"addr": 2, "type": 2, "value": 0},
+    "ACTUAL_ROOM_TEMPERATURE_HC2": {"addr": 3, "type": 2, "value": 0},
+    "SET_ROOM_TEMPERATURE_HC2": {"addr": 4, "type": 2, "value": 0},
+    "RELATIVE_HUMIDITY_HC2": {"addr": 5, "type": 2, "value": 0},
+    "OUTSIDE_TEMPERATURE": {"addr": 6, "type": 2, "value": 0},
+    "ACTUAL_VALUE_HC1": {"addr": 7, "type": 2, "value": 0},
+    "SET_VALUE_HC1": {"addr": 8, "type": 2, "value": 0},
+    "ACTUAL_VALUE_HC2": {"addr": 9, "type": 2, "value": 0},
+    "SET_VALUE_HC2": {"addr": 10, "type": 2, "value": 0},
+    "FLOW_TEMPERATURE": {"addr": 11, "type": 2, "value": 0},
+    "RETURN_TEMPERATURE": {"addr": 12, "type": 2, "value": 0},
+    "PRESSURE_HEATING_CIRCUIT": {"addr": 13, "type": 2, "value": 0},
+    "FLOW_RATE": {"addr": 14, "type": 2, "value": 0},
+    "ACTUAL_DHW_TEMPERATURE": {"addr": 15, "type": 2, "value": 0},
+    "SET_DHW_TEMPERATURE": {"addr": 16, "type": 2, "value": 0},
+    "VENTILATION_AIR_ACTUAL_FAN_SPEED": {"addr": 17, "type": 6, "value": 0},
+    "VENTILATION_AIR_SET_FLOW_RATE": {"addr": 18, "type": 6, "value": 0},
+    "EXTRACT_AIR_ACTUAL_FAN_SPEED": {"addr": 19, "type": 6, "value": 0},
+    "EXTRACT_AIR_SET_FLOW_RATE": {"addr": 20, "type": 6, "value": 0},
+    "EXTRACT_AIR_HUMIDITY": {"addr": 21, "type": 6, "value": 0},
+    "EXTRACT_AIR_TEMPERATURE": {"addr": 22, "type": 2, "value": 0},
+    "EXTRACT_AIR_DEW_POINT": {"addr": 23, "type": 2, "value": 0},
+    "DEW_POINT_TEMPERATUR_HC1": {"addr": 24, "type": 2, "value": 0},
+    "DEW_POINT_TEMPERATUR_HC2": {"addr": 25, "type": 2, "value": 0},
+    "COLLECTOR_TEMPERATURE": {"addr": 26, "type": 2, "value": 0},
+    "HOT_GAS_TEMPERATURE": {"addr": 27, "type": 2, "value": 0},
+    "HIGH_PRESSURE": {"addr": 28, "type": 7, "value": 0},
+    "LOW_PRESSURE": {"addr": 29, "type": 7, "value": 0},
+    "COMPRESSOR_STARTS": {"addr": 30, "type": 6, "value": 0},
+    "COMPRESSOR_SPEED": {"addr": 31, "type": 2, "value": 0},
+    "MIXED_WATER_AMOUNT": {"addr": 32, "type": 6, "value": 0},
 }
 
 
@@ -73,109 +73,87 @@ B1_REGMAP_INPUT = {
 B2_START_ADDR = 1000
 
 B2_REGMAP_HOLDING = {
-    'OPERATING_MODE':           {'addr': 1000, 'type': 8, 'value': 0},
-    'ROOM_TEMP_HEAT_DAY_HC1':   {'addr': 1001, 'type': 2, 'value': 0},
-    'ROOM_TEMP_HEAT_NIGHT_HC1': {'addr': 1002, 'type': 2, 'value': 0},
-    'MANUAL_SET_TEMP_HC1':      {'addr': 1003, 'type': 2, 'value': 0},
-    'ROOM_TEMP_HEAT_DAY_HC2':   {'addr': 1004, 'type': 2, 'value': 0},
-    'ROOM_TEMP_HEAT_NIGHT_HC2': {'addr': 1005, 'type': 2, 'value': 0},
-    'MANUAL_SET_TEAMP_HC2':     {'addr': 1006, 'type': 2, 'value': 0},
-    'GRADIENT_HC1':             {'addr': 1007, 'type': 7, 'value': 0},
-    'LOW_END_HC1':              {'addr': 1008, 'type': 2, 'value': 0},
-    'GRADIENT_HC2':             {'addr': 1009, 'type': 7, 'value': 0},
-    'LOW_END_HC2':              {'addr': 1010, 'type': 2, 'value': 0},
-    'DHW_TEMP_SET_DAY':         {'addr': 1011, 'type': 2, 'value': 0},
-    'DHW_TEMP_SET_NIGHT':       {'addr': 1012, 'type': 2, 'value': 0},
-    'DHW_TEMP_SET_MANUAL':      {'addr': 1013, 'type': 2, 'value': 0},
-    'MWM_SET_DAY':              {'addr': 1014, 'type': 6, 'value': 0},
-    'MWM_SET_NIGHT':            {'addr': 1015, 'type': 6, 'value': 0},
-    'MWM_SET_MANUAL':           {'addr': 1016, 'type': 6, 'value': 0},
-    'DAY_STAGE':                {'addr': 1017, 'type': 6, 'value': 0},
-    'NIGHT_STAGE':              {'addr': 1018, 'type': 6, 'value': 0},
-    'PARTY_STAGE':              {'addr': 1019, 'type': 6, 'value': 0},
-    'MANUAL_STAGE':             {'addr': 1020, 'type': 6, 'value': 0},
-    'ROOM_TEMP_COOL_DAY_HC1':   {'addr': 1021, 'type': 2, 'value': 0},
-    'ROOM_TEMP_COOL_NIGHT_HC1': {'addr': 1022, 'type': 2, 'value': 0},
-    'ROOM_TEMP_COOL_DAY_HC2':   {'addr': 1023, 'type': 2, 'value': 0},
-    'ROOM_TEMP_COOL_NIGHT_HC2': {'addr': 1024, 'type': 2, 'value': 0},
-    'RESET':                    {'addr': 1025, 'type': 6, 'value': 0},
-    'RESTART_ISG':              {'addr': 1026, 'type': 6, 'value': 0}
+    "OPERATING_MODE": {"addr": 1000, "type": 8, "value": 0},
+    "ROOM_TEMP_HEAT_DAY_HC1": {"addr": 1001, "type": 2, "value": 0},
+    "ROOM_TEMP_HEAT_NIGHT_HC1": {"addr": 1002, "type": 2, "value": 0},
+    "MANUAL_SET_TEMP_HC1": {"addr": 1003, "type": 2, "value": 0},
+    "ROOM_TEMP_HEAT_DAY_HC2": {"addr": 1004, "type": 2, "value": 0},
+    "ROOM_TEMP_HEAT_NIGHT_HC2": {"addr": 1005, "type": 2, "value": 0},
+    "MANUAL_SET_TEAMP_HC2": {"addr": 1006, "type": 2, "value": 0},
+    "GRADIENT_HC1": {"addr": 1007, "type": 7, "value": 0},
+    "LOW_END_HC1": {"addr": 1008, "type": 2, "value": 0},
+    "GRADIENT_HC2": {"addr": 1009, "type": 7, "value": 0},
+    "LOW_END_HC2": {"addr": 1010, "type": 2, "value": 0},
+    "DHW_TEMP_SET_DAY": {"addr": 1011, "type": 2, "value": 0},
+    "DHW_TEMP_SET_NIGHT": {"addr": 1012, "type": 2, "value": 0},
+    "DHW_TEMP_SET_MANUAL": {"addr": 1013, "type": 2, "value": 0},
+    "MWM_SET_DAY": {"addr": 1014, "type": 6, "value": 0},
+    "MWM_SET_NIGHT": {"addr": 1015, "type": 6, "value": 0},
+    "MWM_SET_MANUAL": {"addr": 1016, "type": 6, "value": 0},
+    "DAY_STAGE": {"addr": 1017, "type": 6, "value": 0},
+    "NIGHT_STAGE": {"addr": 1018, "type": 6, "value": 0},
+    "PARTY_STAGE": {"addr": 1019, "type": 6, "value": 0},
+    "MANUAL_STAGE": {"addr": 1020, "type": 6, "value": 0},
+    "ROOM_TEMP_COOL_DAY_HC1": {"addr": 1021, "type": 2, "value": 0},
+    "ROOM_TEMP_COOL_NIGHT_HC1": {"addr": 1022, "type": 2, "value": 0},
+    "ROOM_TEMP_COOL_DAY_HC2": {"addr": 1023, "type": 2, "value": 0},
+    "ROOM_TEMP_COOL_NIGHT_HC2": {"addr": 1024, "type": 2, "value": 0},
+    "RESET": {"addr": 1025, "type": 6, "value": 0},
+    "RESTART_ISG": {"addr": 1026, "type": 6, "value": 0},
 }
 
 B2_OPERATING_MODE_READ = {
     # AUTOMATIK
-    11: 'AUTOMATIC',
+    11: "AUTOMATIC",
     # BEREITSCHAFT
-    1: 'STANDBY',
+    1: "STANDBY",
     # TAGBETRIEB
-    3: 'DAY MODE',
+    3: "DAY MODE",
     # ABSENKBETRIEB
-    4: 'SETBACK MODE',
+    4: "SETBACK MODE",
     # WARMWASSER
-    5: 'DHW',
+    5: "DHW",
     # HANDBETRIEB
-    14: 'MANUAL MODE',
+    14: "MANUAL MODE",
     # NOTBETRIEB
-    0: 'EMERGENCY OPERATION'
+    0: "EMERGENCY OPERATION",
 }
 
-B2_OPERATING_MODE_WRITE = {
-    value: key for key, value in B2_OPERATING_MODE_READ.items()
-}
+B2_OPERATING_MODE_WRITE = {value: key for key, value in B2_OPERATING_MODE_READ.items()}
 
-B2_RESET = {
-    'OFF': 0,
-    'ON': 1
-}
+B2_RESET = {"OFF": 0, "ON": 1}
 
-B2_RESTART_ISG = {
-    'OFF': 0,
-    'RESET': 1,
-    'MENU': 2
-}
+B2_RESTART_ISG = {"OFF": 0, "RESET": 1, "MENU": 2}
 
 # Block 3 System status (Read input register) - page 31
 B3_START_ADDR = 2000
 
-B3_REGMAP_INPUT = {
-    'OPERATING_STATUS': {'addr': 2000, 'type': 6, 'value': 0},
-    'FAULT_STATUS':     {'addr': 2001, 'type': 6, 'value': 0},
-    'BUS_STATUS':       {'addr': 2002, 'type': 6, 'value': 0}
-}
+B3_REGMAP_INPUT = {"OPERATING_STATUS": {"addr": 2000, "type": 6, "value": 0}, "FAULT_STATUS": {"addr": 2001, "type": 6, "value": 0}, "BUS_STATUS": {"addr": 2002, "type": 6, "value": 0}}
 
 B3_OPERATING_STATUS = {
-    'SWITCHING_PROGRAM_ENABLED': (1 << 0),
-    'COMPRESSOR': (1 << 1),
-    'HEATING': (1 << 2),
-    'COOLING': (1 << 3),
-    'DHW': (1 << 4),
-    'ELECTRIC_REHEATING': (1 << 5),
-    'SERVICE': (1 << 6),
-    'POWER-OFF': (1 << 7),
-    'FILTER': (1 << 8),
-    'VENTILATION': (1 << 9),
-    'HEATING_CIRCUIT_PUMP': (1 << 10),
-    'EVAPORATOR_DEFROST': (1 << 11),
-    'FILTER_EXTRACT_AIR': (1 << 12),
-    'FILTER_VENTILATION_AIR': (1 << 13),
-    'HEAT-UP_PROGRAM': (1 << 14)
+    "SWITCHING_PROGRAM_ENABLED": (1 << 0),
+    "COMPRESSOR": (1 << 1),
+    "HEATING": (1 << 2),
+    "COOLING": (1 << 3),
+    "DHW": (1 << 4),
+    "ELECTRIC_REHEATING": (1 << 5),
+    "SERVICE": (1 << 6),
+    "POWER-OFF": (1 << 7),
+    "FILTER": (1 << 8),
+    "VENTILATION": (1 << 9),
+    "HEATING_CIRCUIT_PUMP": (1 << 10),
+    "EVAPORATOR_DEFROST": (1 << 11),
+    "FILTER_EXTRACT_AIR": (1 << 12),
+    "FILTER_VENTILATION_AIR": (1 << 13),
+    "HEAT-UP_PROGRAM": (1 << 14),
 }
 
-B3_FAULT_STATUS = {
-    'NO_FAULT': 0,
-    'FAULT': 1
-}
+B3_FAULT_STATUS = {"NO_FAULT": 0, "FAULT": 1}
 
-B3_BUS_STATUS = {
-    'STATUS OK': 0,
-    'STATUS ERROR': -1,
-    'ERROR-PASSIVE': -2,
-    'BUS-OFF': -3,
-    'PHYSICAL-ERROR': -4
-}
+B3_BUS_STATUS = {"STATUS OK": 0, "STATUS ERROR": -1, "ERROR-PASSIVE": -2, "BUS-OFF": -3, "PHYSICAL-ERROR": -4}
 
 
-class StiebelEltronAPI():
+class StiebelEltronAPI:
     """Stiebel Eltron API."""
 
     def __init__(self, conn: ModbusClientMixin, device_id=1, update_on_read=False):
@@ -191,31 +169,22 @@ class StiebelEltronAPI():
         """Request current values from heat pump."""
         ret = True
         try:
-            block_1_result_input = self._conn.read_input_registers(
-                device_id=self._device_id,
-                address=B1_START_ADDR,
-                count=len(self._block_1_input_regs)).registers
-            block_2_result_holding = self._conn.read_holding_registers(
-                device_id=self._device_id,
-                address=B2_START_ADDR,
-                count=len(self._block_2_holding_regs)).registers
-            block_3_result_input = self._conn.read_input_registers(
-                device_id=self._device_id,
-                address=B3_START_ADDR,
-                count=len(self._block_3_input_regs)).registers
+            block_1_result_input = self._conn.read_input_registers(device_id=self._device_id, address=B1_START_ADDR, count=len(self._block_1_input_regs)).registers
+            block_2_result_holding = self._conn.read_holding_registers(device_id=self._device_id, address=B2_START_ADDR, count=len(self._block_2_holding_regs)).registers
+            block_3_result_input = self._conn.read_input_registers(device_id=self._device_id, address=B3_START_ADDR, count=len(self._block_3_input_regs)).registers
         except AttributeError:
             # The unit does not reply reliably
             ret = False
             print("Modbus read failed")
         else:
             for v in self._block_1_input_regs.values():
-                v['value'] = block_1_result_input[v['addr'] - B1_START_ADDR]
+                v["value"] = block_1_result_input[v["addr"] - B1_START_ADDR]
 
             for v in self._block_2_holding_regs.values():
-                v['value'] = block_2_result_holding[v['addr'] - B2_START_ADDR]
+                v["value"] = block_2_result_holding[v["addr"] - B2_START_ADDR]
 
             for v in self._block_3_input_regs.values():
-                v['value'] = block_3_result_input[v['addr'] - B3_START_ADDR]
+                v["value"] = block_3_result_input[v["addr"] - B3_START_ADDR]
 
         return ret
 
@@ -236,31 +205,31 @@ class StiebelEltronAPI():
         if value_entry is None:
             return None
 
-        if value_entry['type'] == 2:
-            return value_entry['value'] * 0.1
-        if value_entry['type'] == 7:
-            return value_entry['value'] * 0.01
+        if value_entry["type"] == 2:
+            return value_entry["value"] * 0.1
+        if value_entry["type"] == 7:
+            return value_entry["value"] * 0.01
 
-        return value_entry['value']
+        return value_entry["value"]
 
-#    def get_raw_input_register(self, name):
-#        """Get raw register value by name."""
-#        if self._update_on_read:
-#            self.update()
-#        return self._block_1_input_regs[name]
+    #    def get_raw_input_register(self, name):
+    #        """Get raw register value by name."""
+    #        if self._update_on_read:
+    #            self.update()
+    #        return self._block_1_input_regs[name]
 
-#    def get_raw_holding_register(self, name):
-#        """Get raw register value by name."""
-#        if self._update_on_read:
-#            self.update()
-#        return self._block_2_holding_regs[name]
+    #    def get_raw_holding_register(self, name):
+    #        """Get raw register value by name."""
+    #        if self._update_on_read:
+    #            self.update()
+    #        return self._block_2_holding_regs[name]
 
-#    def set_raw_holding_register(self, name, value):
-#        """Write to register by name."""
-#        self._conn.write_register(
-#            device_id=self._device_id,
-#            address=(self._holding_regs[name]['addr']),
-#            value=value)
+    #    def set_raw_holding_register(self, name, value):
+    #        """Write to register by name."""
+    #        self._conn.write_register(
+    #            device_id=self._device_id,
+    #            address=(self._holding_regs[name]['addr']),
+    #            value=value)
 
     # Handle room temperature & humidity
 
@@ -268,27 +237,23 @@ class StiebelEltronAPI():
         """Get the current room temperature."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val('ACTUAL_ROOM_TEMPERATURE_HC1')
+        return self.get_conv_val("ACTUAL_ROOM_TEMPERATURE_HC1")
 
     def get_target_temp(self):
         """Get the target room temperature."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val('ROOM_TEMP_HEAT_DAY_HC1')
+        return self.get_conv_val("ROOM_TEMP_HEAT_DAY_HC1")
 
     def set_target_temp(self, temp: float):
         """Set the target room temperature (day)(HC1)."""
-        self._conn.write_register(
-            device_id=self._device_id,
-            address=(
-                self._block_2_holding_regs['ROOM_TEMP_HEAT_DAY_HC1']['addr']),
-            value=round(temp * 10.0))
+        self._conn.write_register(device_id=self._device_id, address=(self._block_2_holding_regs["ROOM_TEMP_HEAT_DAY_HC1"]["addr"]), value=round(temp * 10.0))
 
     def get_current_humidity(self):
         """Get the current room humidity."""
         if self._update_on_read:
             self.update()
-        return self.get_conv_val('RELATIVE_HUMIDITY_HC1')
+        return self.get_conv_val("RELATIVE_HUMIDITY_HC1")
 
     # Handle operation mode
 
@@ -297,15 +262,12 @@ class StiebelEltronAPI():
         if self._update_on_read:
             self.update()
 
-        op_mode = self.get_conv_val('OPERATING_MODE')
-        return B2_OPERATING_MODE_READ.get(op_mode, 'UNKNOWN')
+        op_mode = self.get_conv_val("OPERATING_MODE")
+        return B2_OPERATING_MODE_READ.get(op_mode, "UNKNOWN")
 
     def set_operation(self, mode: str):
         """Set the operation mode."""
-        self._conn.write_register(
-            device_id=self._device_id,
-            address=(self._block_2_holding_regs['OPERATING_MODE']['addr']),
-            value=B2_OPERATING_MODE_WRITE.get(mode))
+        self._conn.write_register(device_id=self._device_id, address=(self._block_2_holding_regs["OPERATING_MODE"]["addr"]), value=B2_OPERATING_MODE_WRITE.get(mode))
 
     # Handle device status
 
@@ -313,22 +275,18 @@ class StiebelEltronAPI():
         """Return heater status."""
         if self._update_on_read:
             self.update()
-        return bool(self.get_conv_val('OPERATING_STATUS') &
-                    B3_OPERATING_STATUS['HEATING'])
+        return bool(self.get_conv_val("OPERATING_STATUS") & B3_OPERATING_STATUS["HEATING"])
 
     def get_cooling_status(self):
         """Cooling status."""
         if self._update_on_read:
             self.update()
-        return bool(self.get_conv_val('OPERATING_STATUS') &
-                    B3_OPERATING_STATUS['COOLING'])
+        return bool(self.get_conv_val("OPERATING_STATUS") & B3_OPERATING_STATUS["COOLING"])
 
     def get_filter_alarm_status(self):
         """Return filter alarm."""
         if self._update_on_read:
             self.update()
 
-        filter_mask = (B3_OPERATING_STATUS['FILTER'] |
-                       B3_OPERATING_STATUS['FILTER_EXTRACT_AIR'] |
-                       B3_OPERATING_STATUS['FILTER_VENTILATION_AIR'])
-        return bool(self.get_conv_val('OPERATING_STATUS') & filter_mask)
+        filter_mask = B3_OPERATING_STATUS["FILTER"] | B3_OPERATING_STATUS["FILTER_EXTRACT_AIR"] | B3_OPERATING_STATUS["FILTER_VENTILATION_AIR"]
+        return bool(self.get_conv_val("OPERATING_STATUS") & filter_mask)

--- a/pystiebeleltron/wpm.py
+++ b/pystiebeleltron/wpm.py
@@ -874,7 +874,7 @@ WPM_ENERGY_DATA_REGISTERS = {
 
 
 class WpmStiebelEltronAPI(StiebelEltronAPI):
-    def __init__(self, host: str, port: int = 502, slave: int = 1) -> None:
+    def __init__(self, host: str, port: int = 502, device_id: int = 1) -> None:
         super().__init__(
             [
                 ModbusRegisterBlock(base_address=500, count=110, name="System Values", registers=WPM_SYSTEM_VALUES_REGISTERS, register_type=RegisterType.INPUT_REGISTER),
@@ -886,7 +886,7 @@ class WpmStiebelEltronAPI(StiebelEltronAPI):
             ],
             host,
             port,
-            slave,
+            device_id,
         )
 
     async def async_update(self):

--- a/scripts/templates/lwztemplate.j2
+++ b/scripts/templates/lwztemplate.j2
@@ -42,14 +42,14 @@ class OperatingMode(Enum):
 
 class {{heatpump_type}}StiebelEltronAPI(StiebelEltronAPI):
 
-    def __init__(self, host: str, port: int = 502, slave: int = 1) -> None:
+    def __init__(self, host: str, port: int = 502, device_id: int = 1) -> None:
         super().__init__([
             {% for registerblock in registers %}
                 ModbusRegisterBlock(base_address={{registerblock["base_address"]}}, count={{registerblock["count"]}}, name="{{registerblock["name"]}}", registers={{heatpump_type.upper()}}_{{python_name(registerblock["name"]).upper()}}_REGISTERS, register_type={{registerblock["register_type"]}}),{% endfor %}
                 ModbusRegisterBlock(base_address=4000, count=3, name="Energy Management Settings", registers=ENERGY_MANAGEMENT_SETTINGS_REGISTERS, register_type=RegisterType.HOLDING_REGISTER),
                 ModbusRegisterBlock(base_address=5000, count=2, name="Energy System Information", registers=ENERGY_SYSTEM_INFORMATION_REGISTERS, register_type=RegisterType.INPUT_REGISTER),
             ],
-            host, port, slave)
+            host, port, device_id)
 
     async def async_update(self):
         """Request current values from heat pump."""

--- a/scripts/templates/wpmtemplate.j2
+++ b/scripts/templates/wpmtemplate.j2
@@ -21,14 +21,14 @@ class {{heatpump_type}}{{python_class_name(registerblock["name"])}}Registers(Isg
 
 class {{heatpump_type}}StiebelEltronAPI(StiebelEltronAPI):
 
-    def __init__(self, host: str, port: int = 502, slave: int = 1) -> None:
+    def __init__(self, host: str, port: int = 502, device_id: int = 1) -> None:
         super().__init__([
             {% for registerblock in registers %}
                 ModbusRegisterBlock(base_address={{registerblock["base_address"]}}, count={{registerblock["count"]}}, name="{{registerblock["name"]}}", registers={{heatpump_type.upper()}}_{{python_name(registerblock["name"]).upper()}}_REGISTERS, register_type={{registerblock["register_type"]}}),{% endfor %}
                 ModbusRegisterBlock(base_address=4000, count=3, name="Energy Management Settings", registers=ENERGY_MANAGEMENT_SETTINGS_REGISTERS, register_type=RegisterType.HOLDING_REGISTER),
                 ModbusRegisterBlock(base_address=5000, count=2, name="Energy System Information", registers=ENERGY_SYSTEM_INFORMATION_REGISTERS, register_type=RegisterType.INPUT_REGISTER),
             ],
-            host, port, slave)
+            host, port, device_id)
 
     async def async_update(self):
         """Request current values from heat pump."""

--- a/test/mock_modbus_server.py
+++ b/test/mock_modbus_server.py
@@ -86,7 +86,7 @@ class MockModbusServer(object):
         store = ModbusDeviceContext(
             hr=ModbusSequentialDataBlock(0, [0]*3000),
             ir=ModbusSequentialDataBlock(0, [0]*3000))
-        self.context = ModbusServerContext(device_ids=store, single=True)
+        self.context = ModbusServerContext(devices=store, single=True)
 
         # ----------------------------------------------------------------------- #
         # initialize the server information

--- a/test/mock_modbus_server.py
+++ b/test/mock_modbus_server.py
@@ -14,7 +14,7 @@ from pymodbus.server import StartTcpServer, ServerStop
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
-from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
+from pymodbus.datastore import ModbusDeviceContext, ModbusServerContext
 
 
 class MockModbusServer(object):
@@ -51,8 +51,8 @@ class MockModbusServer(object):
         # or simply do not pass them to have them initialized to 0x00 on the full
         # address range::
         #
-        #     store = ModbusSlaveContext(di = ModbusSequentialDataBlock.create())
-        #     store = ModbusSlaveContext()
+        #     store = Modbusdevice_idContext(di = ModbusSequentialDataBlock.create())
+        #     store = Modbusdevice_idContext()
         #
         # Finally, you are allowed to use the same DataBlock reference for every
         # table or you you may use a seperate DataBlock for each table.
@@ -60,33 +60,33 @@ class MockModbusServer(object):
         # the same data or not::
         #
         #     block = ModbusSequentialDataBlock(0x00, [0]*0xff)
-        #     store = ModbusSlaveContext(di=block, co=block, hr=block, ir=block)
+        #     store = Modbusdevice_idContext(di=block, co=block, hr=block, ir=block)
         #
         # The server then makes use of a server context that allows the server to
-        # respond with different slave contexts for different unit ids. By default
+        # respond with different device_id contexts for different unit ids. By default
         # it will return the same context for every unit id supplied (broadcast
         # mode).
         # However, this can be overloaded by setting the single flag to False
         # and then supplying a dictionary of unit id to context mapping::
         #
-        #     slaves  = {
-        #         0x01: ModbusSlaveContext(...),
-        #         0x02: ModbusSlaveContext(...),
-        #         0x03: ModbusSlaveContext(...),
+        #     device_ids  = {
+        #         0x01: Modbusdevice_idContext(...),
+        #         0x02: Modbusdevice_idContext(...),
+        #         0x03: Modbusdevice_idContext(...),
         #     }
-        #     context = ModbusServerContext(slaves=slaves, single=False)
+        #     context = ModbusServerContext(device_ids=device_ids, single=False)
         #
-        # The slave context can also be initialized in zero_mode which means that a
+        # The device_id context can also be initialized in zero_mode which means that a
         # request to address(0-7) will map to the address (0-7). The default is
         # False which is based on section 4.4 of the specification, so address(0-7)
         # will map to (1-8)::
         #
-        #     store = ModbusSlaveContext(..., zero_mode=True)
+        #     store = Modbusdevice_idContext(..., zero_mode=True)
         # ----------------------------------------------------------------------- #
-        store = ModbusSlaveContext(
+        store = Modbusdevice_idContext(
             hr=ModbusSequentialDataBlock(0, [0]*3000),
             ir=ModbusSequentialDataBlock(0, [0]*3000))
-        self.context = ModbusServerContext(slaves=store, single=True)
+        self.context = ModbusServerContext(device_ids=store, single=True)
 
         # ----------------------------------------------------------------------- #
         # initialize the server information
@@ -122,12 +122,12 @@ class MockModbusServer(object):
         :param values: List of values
         """
         assert register == 3 or register == 4
-        slave_id = 0x00
-        old_values = self.context[slave_id].getValues(register,
+        device_id = 0x00
+        old_values = self.context[device_id].getValues(register,
                                                       address, count=1)
         self.log.debug("Change value at address {} from {} to {}".format(
             address, old_values, values))
-        self.context[slave_id].setValues(register, address, values)
+        self.context[device_id].setValues(register, address, values)
 
     def update_holding_register(self, address, value):
         """ Update value of a holding register.

--- a/test/mock_modbus_server.py
+++ b/test/mock_modbus_server.py
@@ -12,7 +12,7 @@ of nodes which can be helpful for testing monitoring software.
 # --------------------------------------------------------------------------- #
 from pymodbus.server import StartTcpServer, ServerStop
 
-from pymodbus.device import ModbusDeviceIdentification
+from pymodbus.pdu.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusDeviceContext, ModbusServerContext
 

--- a/test/mock_modbus_server.py
+++ b/test/mock_modbus_server.py
@@ -51,8 +51,8 @@ class MockModbusServer(object):
         # or simply do not pass them to have them initialized to 0x00 on the full
         # address range::
         #
-        #     store = Modbusdevice_idContext(di = ModbusSequentialDataBlock.create())
-        #     store = Modbusdevice_idContext()
+        #     store = ModbusDeviceContext(di = ModbusSequentialDataBlock.create())
+        #     store = ModbusDeviceContext()
         #
         # Finally, you are allowed to use the same DataBlock reference for every
         # table or you you may use a seperate DataBlock for each table.
@@ -60,7 +60,7 @@ class MockModbusServer(object):
         # the same data or not::
         #
         #     block = ModbusSequentialDataBlock(0x00, [0]*0xff)
-        #     store = Modbusdevice_idContext(di=block, co=block, hr=block, ir=block)
+        #     store = ModbusDeviceContext(di=block, co=block, hr=block, ir=block)
         #
         # The server then makes use of a server context that allows the server to
         # respond with different device_id contexts for different unit ids. By default
@@ -70,9 +70,9 @@ class MockModbusServer(object):
         # and then supplying a dictionary of unit id to context mapping::
         #
         #     device_ids  = {
-        #         0x01: Modbusdevice_idContext(...),
-        #         0x02: Modbusdevice_idContext(...),
-        #         0x03: Modbusdevice_idContext(...),
+        #         0x01: ModbusDeviceContext(...),
+        #         0x02: ModbusDeviceContext(...),
+        #         0x03: ModbusDeviceContext(...),
         #     }
         #     context = ModbusServerContext(device_ids=device_ids, single=False)
         #
@@ -81,9 +81,9 @@ class MockModbusServer(object):
         # False which is based on section 4.4 of the specification, so address(0-7)
         # will map to (1-8)::
         #
-        #     store = Modbusdevice_idContext(..., zero_mode=True)
+        #     store = ModbusDeviceContext(..., zero_mode=True)
         # ----------------------------------------------------------------------- #
-        store = Modbusdevice_idContext(
+        store = ModbusDeviceContext(
             hr=ModbusSequentialDataBlock(0, [0]*3000),
             ir=ModbusSequentialDataBlock(0, [0]*3000))
         self.context = ModbusServerContext(device_ids=store, single=True)

--- a/test/test_pystiebeleltron.py
+++ b/test/test_pystiebeleltron.py
@@ -14,7 +14,7 @@ from pystiebeleltron import pystiebeleltron as pyse
 # Modbus server connection details
 host_ip = "127.0.0.1" #"192.168.1.20"
 host_port = 5020 #502
-slave = 1
+device_id = 1
 
 
 class TestStiebelEltronApi:
@@ -49,7 +49,7 @@ class TestStiebelEltronApi:
     def pyse_api(self, request, pymb_s):
         # parameter pymb_s leads to call of fixture
         mb_c = ModbusClient(host=host_ip, port=host_port, timeout=2)
-        api = pyse.StiebelEltronAPI(mb_c, slave, update_on_read=True)
+        api = pyse.StiebelEltronAPI(mb_c, device_id, update_on_read=True)
 
         # Cleanup after last test (will run as well, if setup fails).
         def fin():

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -6,7 +6,7 @@ from pymodbus.pdu.register_message import (
 )
 
 
-async def read_registers(client, address: int, *, count: int = 1, slave: int = 0, no_response_expected: bool = False) -> ReadInputRegistersResponse:
+async def read_registers(client, address: int, *, count: int = 1, device_id: int = 0, no_response_expected: bool = False) -> ReadInputRegistersResponse:
     """Read a slice from the input register."""
     return ReadInputRegistersResponse(address=address, count=count, registers=list(range(count)))
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 
 [[package]]
@@ -119,11 +119,11 @@ wheels = [
 
 [[package]]
 name = "pymodbus"
-version = "3.9.2"
+version = "3.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9e/9f/434efbc3edd1445efca2c17d24877010746d65783ddbb937de753de6bec7/pymodbus-3.9.2.tar.gz", hash = "sha256:2d08ab7bf6d1abc55a87f4faa3a7b04f74d7310b8c9771c3d66ee5fccf2e25ac", size = 163040, upload-time = "2025-04-18T15:24:36.377Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a7/ff43634e43fedc132e876f8b82b84c103b329f66297346f43e2e6c9c04a4/pymodbus-3.11.0.tar.gz", hash = "sha256:cbb12041d67a9bcd3ab1c6f39afc7c19f23bb770def2a660b8bb72779ba51ee4", size = 161346, upload-time = "2025-08-05T15:26:23.757Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/7e/ae151f2750fb604247088774634fea321a178fb898cf8e961879825f9e41/pymodbus-3.9.2-py3-none-any.whl", hash = "sha256:292dcf859d6f232c30abc9753c1f0b7804771fd9c749641b32831de01b360b30", size = 165153, upload-time = "2025-04-18T15:24:34.428Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/cd/ab6f675ae0cac8ae25103eb8b2f97e907edd3c6fe153ef4ef1d030fc62ec/pymodbus-3.11.0-py3-none-any.whl", hash = "sha256:34ef7154b32edffff77b5babd9b9aab8b4c9a1404b8badfa86f12d9e14bce02e", size = 163531, upload-time = "2025-08-05T15:26:22.068Z" },
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymodbus", specifier = ">=3.8.3" }]
+requires-dist = [{ name = "pymodbus", specifier = ">=3.10.0" }]
 
 [package.metadata.requires-dev]
 dev = [

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymodbus", specifier = ">=3.10.0" }]
+requires-dist = [{ name = "pymodbus", specifier = ">=3.10.0,<4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Hi together,

I don't contribute that much code 😄 and i dunno if i understood every piece of your helpful library.

With pymodbus 3.10.0 there were some changes which were introduced with this PR https://github.com/pymodbus-dev/pymodbus/pull/2600. 

Especially those should be interesting for this project:

- ModbusSlaveContext replaced by ModbusDeviceContext
- slave=, slaves= replaced by device_id=, device_ids=

i tried my best to adapt this into your code, but please have another look into it. I could check it with my home assistant instance and this addon https://github.com/pail23/stiebel_eltron_isg_component and it seems to work again 👍 

Kind regards,
David

