### PR TITLE
Update pymodbus to 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.10,<4"
 dependencies = [
-    "pymodbus (>=3.10.0,<4)",
+    "pymodbus>=3.13,<4",
 ]
 
 [build-system]

--- a/test/mock_modbus_server.py
+++ b/test/mock_modbus_server.py
@@ -10,12 +10,15 @@ of nodes which can be helpful for testing monitoring software.
 
 from __future__ import annotations
 
+import asyncio
+
 # --------------------------------------------------------------------------- #
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.datastore import ModbusDeviceContext, ModbusSequentialDataBlock, ModbusServerContext
 from pymodbus.pdu.device import ModbusDeviceIdentification
 from pymodbus.server import ServerStop, StartTcpServer
+from pymodbus.server.base import ModbusBaseServer
 
 
 class MockModbusServer(object):
@@ -84,7 +87,7 @@ class MockModbusServer(object):
         #
         #     store = ModbusDeviceContext(..., zero_mode=True)
         # ----------------------------------------------------------------------- #
-        store = ModbusDeviceContext(hr=ModbusSequentialDataBlock(0, [0] * 3000), ir=ModbusSequentialDataBlock(0, [0] * 3000))
+        store = ModbusDeviceContext(hr=ModbusSequentialDataBlock(1, [0] * 3000), ir=ModbusSequentialDataBlock(1, [0] * 3000))
         self.context = ModbusServerContext(devices=store, single=True)
 
         # ----------------------------------------------------------------------- #
@@ -122,9 +125,13 @@ class MockModbusServer(object):
         """
         assert register == 3 or register == 4
         device_id = 0x00
-        old_values = self.context[device_id].getValues(register, address, count=1)
+        server = ModbusBaseServer.active_server
+        if server is None:
+            return
+
+        old_values = asyncio.run_coroutine_threadsafe(server.async_getValues(device_id, register, address, count=1), server.loop).result()
         self.log.debug("Change value at address {} from {} to {}".format(address, old_values, values))
-        self.context[device_id].setValues(register, address, values)
+        asyncio.run_coroutine_threadsafe(server.async_setValues(device_id, register, address, values), server.loop).result()
 
     def update_holding_register(self, address: int, value: float) -> None:
         """Update value of a holding register.

--- a/uv.lock
+++ b/uv.lock
@@ -332,11 +332,11 @@ wheels = [
 
 [[package]]
 name = "pymodbus"
-version = "3.11.4"
+version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2a/af/bbb716301ab9c60f0702c3cdf72cc0e373286a5648fe16bc4431400489dc/pymodbus-3.11.4.tar.gz", hash = "sha256:6910e385cb6b2f983cd457e9ecee2ff580dbb23cf3d84aefec0845e71edd606a", size = 163422, upload-time = "2025-11-30T10:36:33.717Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/55/eee0782c2ca9fa8e7c3218caca22fe30e850cd6c0c0d475c10b8c19e5a36/pymodbus-3.13.0.tar.gz", hash = "sha256:da4c87afe772787620594c564cd8aa8a4c58ff9786382aba9550fe0ce8879f32", size = 165750, upload-time = "2026-04-12T07:43:23.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/80/84c32440949c77f2c201c38e5fa56fd8f19da31bf24df55bdbdaba67767c/pymodbus-3.11.4-py3-none-any.whl", hash = "sha256:89865929f53bd5e32b4076dde00ee86d9b8afb1686832ed74e69d55df22729c3", size = 166002, upload-time = "2025-11-30T10:36:31.992Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9e/6046aa966c04f72417e7f3ee25cec975f770c934ccf83aa6b0c77400ff12/pymodbus-3.13.0-py3-none-any.whl", hash = "sha256:6ce838690b59ef3da00893699d04dc56e60abfb5b569363b7d6526470a3a44f5", size = 166398, upload-time = "2026-04-12T07:43:21.522Z" },
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pymodbus", specifier = ">=3.10.0,<4" }]
+requires-dist = [{ name = "pymodbus", specifier = ">=3.13,<4" }]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This applies #21, and adapts test/mock_modbus_server.py for it to work with the new version.