### PR TITLE
Decode scaled registers without binary-float artefacts

### DIFF
--- a/pystiebeleltron/__init__.py
+++ b/pystiebeleltron/__init__.py
@@ -242,7 +242,7 @@ class StiebelEltronAPI:
             if isinstance(value, int):
                 if value == -32768:
                     return None
-                return float(value) * 0.1
+                return value / 10
         elif register_description.data_type == 6:
             value = self._client.convert_from_registers([register], self._client.DATATYPE.UINT16)
             if isinstance(value, int):
@@ -254,7 +254,7 @@ class StiebelEltronAPI:
             if isinstance(value, int):
                 if value == -32768:
                     return None
-                return value * 0.01
+                return value / 100
         elif register_description.data_type == 8:
             value = self._client.convert_from_registers([register], self._client.DATATYPE.UINT16)
             if isinstance(value, int):

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -23,7 +23,7 @@ async def test_scaled_register_decode_is_precise() -> None:
 
     # data_type 2 is scaled by 0.1, data_type 7 by 0.01.
     assert api.convert_value_from_modbus(71, descriptor(2)) == 7.1
-    assert api.convert_value_from_modbus(7, descriptor(7)) == 0.07
+    assert api.convert_value_from_modbus(32765, descriptor(7)) == 327.65
 
 
 async def read_registers(client: object, address: int, *, count: int = 1, device_id: int = 0, no_response_expected: bool = False) -> ReadInputRegistersResponse:

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -6,9 +6,24 @@ from pymodbus.pdu.register_message import (
 )
 from pytest_mock import MockerFixture
 
-from pystiebeleltron import ControllerModel, StiebelEltronModbusError, get_controller_model
+from pystiebeleltron import ControllerModel, ModbusRegister, StiebelEltronModbusError, get_controller_model
 from pystiebeleltron.lwz import LwzEnergyDataRegisters, LwzStiebelEltronAPI, LwzSystemValuesRegisters, OperatingMode
 from pystiebeleltron.wpm import WpmEnergyDataRegisters, WpmPowerConsumptionRegisters, WpmStiebelEltronAPI, WpmSystemValuesRegisters
+
+
+@pytest.mark.asyncio()
+async def test_scaled_register_decode_is_precise() -> None:
+    """Scaled registers decode without binary-float artefacts (e.g. 7.1, not 7.1000000000000005)."""
+    api = WpmStiebelEltronAPI("localhost")
+
+    def descriptor(data_type: int) -> ModbusRegister:
+        return ModbusRegister(
+            address=1, name="x", unit="", min=None, max=None, data_type=data_type, key=WpmSystemValuesRegisters.ACTUAL_TEMPERATURE_FEK
+        )
+
+    # data_type 2 is scaled by 0.1, data_type 7 by 0.01.
+    assert api.convert_value_from_modbus(71, descriptor(2)) == 7.1
+    assert api.convert_value_from_modbus(7, descriptor(7)) == 0.07
 
 
 async def read_registers(client: object, address: int, *, count: int = 1, device_id: int = 0, no_response_expected: bool = False) -> ReadInputRegistersResponse:


### PR DESCRIPTION
## What

`convert_value_from_modbus` decoded scaled registers with a floating-point multiply:

- `data_type == 2`: `float(value) * 0.1`
- `data_type == 7`: `value * 0.01`

Because `0.1` and `0.01` are not exactly representable in binary floating point, the multiply introduces artefacts — e.g. raw `71` decoded to `7.1000000000000005` instead of `7.1`. This happens for ~36% of integer inputs (any value where `raw * 0.1 != raw / 10`).

## How

Divide by `10` / `100` instead. Integer division-by-ten is correctly rounded to the nearest representable float for all inputs, so raw `71` decodes to exactly `7.1`. No scaling behaviour changes — only the float representation becomes clean.

This makes downstream exact comparisons (e.g. "has this value changed?" guards in consumers like the Home Assistant integration) behave correctly.

## Testing

- Added `test_scaled_register_decode_is_precise` covering a previously imprecise data_type 2 and data_type 7 value.
- `test/test_stiebel_eltron.py` passes (11 tests); `ruff` clean; `mypy` unchanged (the pre-existing warnings are in `convert_value_to_modbus`, untouched here).

(The `test/test_pystiebeleltron.py` mock-server tests fail to bind locally against the installed pymodbus version, unrelated to this change.)