### PR TITLE
Distinguish unknown controller model from comms errors

### DIFF
--- a/pystiebeleltron/__init__.py
+++ b/pystiebeleltron/__init__.py
@@ -66,12 +66,7 @@ class StiebelEltronModbusError(Exception):
 
 
 class UnknownControllerModelError(Exception):
-    """The controller reported a model id we don't recognize.
-
-    Unlike :class:`StiebelEltronModbusError` this is not a transient comms
-    failure: the read succeeded but returned an id absent from
-    :class:`ControllerModel`, so retrying won't help.
-    """
+    """The controller reported a model id we don't recognize."""
 
     def __init__(self, model_id: int) -> None:
         """Initialize the error with the unrecognized ``model_id``."""

--- a/pystiebeleltron/__init__.py
+++ b/pystiebeleltron/__init__.py
@@ -65,6 +65,20 @@ class StiebelEltronModbusError(Exception):
         super().__init__("Data error on the modbus")
 
 
+class UnknownControllerModelError(Exception):
+    """The controller reported a model id we don't recognize.
+
+    Unlike :class:`StiebelEltronModbusError` this is not a transient comms
+    failure: the read succeeded but returned an id absent from
+    :class:`ControllerModel`, so retrying won't help.
+    """
+
+    def __init__(self, model_id: int) -> None:
+        """Initialize the error with the unrecognized ``model_id``."""
+        self.model_id = model_id
+        super().__init__(f"Unknown controller model id: {model_id}")
+
+
 class ControllerModel(Enum):
     """Controller model."""
 
@@ -85,9 +99,13 @@ async def get_controller_model(unit: ModbusUnit) -> ControllerModel:
     """
     try:
         registers = await unit.read_input_registers(5001, 1)
-        return ControllerModel(registers[0])
-    except (ModbusError, IndexError, ValueError) as err:
+        model_id = registers[0]
+    except (ModbusError, IndexError) as err:
         raise StiebelEltronModbusError from err
+    try:
+        return ControllerModel(model_id)
+    except ValueError as err:
+        raise UnknownControllerModelError(model_id) from err
 
 
 class EnergyManagementSettings(Component):

--- a/scripts/query.py
+++ b/scripts/query.py
@@ -26,7 +26,7 @@ from typing import cast
 from modbus_connection import ModbusConnection, ModbusError, ModbusUnit
 from modbus_connection.model import Component, RegisterField, RepeatingGroupField
 
-from pystiebeleltron import StiebelEltronModbusError, get_controller_model
+from pystiebeleltron import StiebelEltronModbusError, UnknownControllerModelError, get_controller_model
 from pystiebeleltron.lwz import LwzStiebelEltronAPI
 from pystiebeleltron.wpm import WpmStiebelEltronAPI
 
@@ -166,7 +166,7 @@ async def _run(args: argparse.Namespace) -> int:
         start = time.monotonic()
         await api.async_update()
         elapsed = time.monotonic() - start
-    except (ModbusError, StiebelEltronModbusError) as err:
+    except (ModbusError, StiebelEltronModbusError, UnknownControllerModelError) as err:
         print(f"Error reading device: {err}", file=sys.stderr)
         return 1
     finally:

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -4,7 +4,12 @@ import pytest
 from modbus_connection.mock import MockModbusConnection, MockModbusUnit
 from modbus_connection.model import Component
 
-from pystiebeleltron import ControllerModel, StiebelEltronModbusError, get_controller_model
+from pystiebeleltron import (
+    ControllerModel,
+    StiebelEltronModbusError,
+    UnknownControllerModelError,
+    get_controller_model,
+)
 from pystiebeleltron.lwz import LwzStiebelEltronAPI, OperatingMode
 from pystiebeleltron.wpm import WpmStiebelEltronAPI
 
@@ -159,10 +164,12 @@ async def test_get_controller_model_error_response(mock_modbus_connection: MockM
 
 @pytest.mark.asyncio()
 async def test_get_controller_model_unknown_id(mock_modbus_unit: MockModbusUnit) -> None:
-    """An unrecognized model id surfaces as StiebelEltronModbusError, not ValueError."""
+    """An unrecognized model id surfaces as UnknownControllerModelError, not a comms error."""
     mock_modbus_unit.input[5001] = 999
-    with pytest.raises(StiebelEltronModbusError):
+    with pytest.raises(UnknownControllerModelError) as exc_info:
         await get_controller_model(mock_modbus_unit)
+    assert exc_info.value.model_id == 999
+    assert not isinstance(exc_info.value, StiebelEltronModbusError)
 
 
 @pytest.mark.asyncio()


### PR DESCRIPTION
## What

`get_controller_model` in 0.5.0 caught `(ModbusError, IndexError, ValueError)` in a single block and wrapped all of them into `StiebelEltronModbusError`. That conflated two fundamentally different failures:

- a **transient comms glitch** — `ModbusError`, or a short read surfacing as `IndexError` — which is retryable
- a **genuinely unknown model id** — the read succeeded but returned an id absent from `ControllerModel`, raising `ValueError` — which is permanent and won't improve on retry

Callers had no way to tell them apart.

## Changes

- `pystiebeleltron/__init__.py`: the read failure (`ModbusError` / short-read `IndexError`) still raises `StiebelEltronModbusError`; a successful read that returns an unrecognized id now raises a new `UnknownControllerModelError`, carrying the offending `model_id`. It is intentionally **not** a subclass of `StiebelEltronModbusError`, since the modbus read itself succeeded.
- `test/test_stiebel_eltron.py`: the unknown-id test now asserts `UnknownControllerModelError`, checks `.model_id`, and confirms it is not a `StiebelEltronModbusError`.
- `scripts/query.py`: its device-read error handler also catches `UnknownControllerModelError` so it still reports cleanly.

## Compatibility note

This is an API-visible change: code that today catches `StiebelEltronModbusError` to handle an unrecognized model will no longer catch that case. Worth a version bump / changelog entry.

## Testing

- `pytest` — 15 passed
- `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jHHmqB3gk9DPKJ7qCV7fz
