### PR TITLE
Migrate to modbus-connection 3.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<4"
 dependencies = [
-    "modbus-connection[pymodbus] (>=3.6.0)",
+    "modbus-connection[pymodbus] (>=3.7.0)",
     "pymodbus (>=3.10.0,<4)",
 ]
 

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from modbus_connection import ModbusError, ModbusExceptionError
 from modbus_connection.mock import MockModbusConnection, MockModbusUnit
 from modbus_connection.model import Component
 
@@ -183,3 +184,26 @@ async def test_energy_counter_unavailable(mock_modbus_unit: MockModbusUnit) -> N
 
     assert api.energy_data.heat_meter_htg_ttl is None
     assert api.energy_data.heat_meter_htg_day_and_total is None
+
+
+@pytest.mark.asyncio()
+async def test_async_update_surfaces_refused_block(mock_modbus_unit: MockModbusUnit) -> None:
+    """A device that refuses a register block (e.g. an uninstalled module) errors out.
+
+    ``async_update`` pools reads into per-space blocks; if the controller answers
+    one with a Modbus exception, that surfaces as a ``ModbusError`` rather than
+    quietly leaving those fields at their previous values.
+    """
+    api = WpmStiebelEltronAPI(mock_modbus_unit)
+    _seed(mock_modbus_unit, api.system_values)
+    # 502 falls inside the first input block; illegal-data-address (2) mimics a
+    # controller that doesn't serve that block.
+    mock_modbus_unit.fail_read(502, ModbusExceptionError(2), register_type="input")
+
+    with pytest.raises(ModbusError):
+        await api.async_update()
+
+    # Clearing the failure lets the same update succeed.
+    mock_modbus_unit.fail_read(502, None, register_type="input")
+    await api.async_update()
+    assert api.system_values.actual_temperature_fek == 0.2

--- a/uv.lock
+++ b/uv.lock
@@ -204,11 +204,11 @@ wheels = [
 
 [[package]]
 name = "modbus-connection"
-version = "3.6.0"
+version = "3.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a3/15/005df3d65c96e471579beb457fcc2f3096159c850a39b884c84d110c0184/modbus_connection-3.6.0.tar.gz", hash = "sha256:2dc87c5eb70386d51e51f640957fe448b7107eed9cc67ef71e048796c71722e8", size = 168387, upload-time = "2026-07-13T19:39:33.739Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/72/71a0bba6647f1b02058c5479babcad9c181db49c46e3e1aaa7680462351e/modbus_connection-3.7.0.tar.gz", hash = "sha256:6500a13c3b6779615b354f3fc77e7ac25b8104136868c759305e48f57a65496b", size = 187991, upload-time = "2026-07-14T17:18:10.094Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/e2/18f82e1a70472af9c79407c6001ea7e59ef21caf781285936845f980c5ff/modbus_connection-3.6.0-py3-none-any.whl", hash = "sha256:84ca1cd809e34d40d28596e23b113be47a28df0fba72ae37b028c91e87341312", size = 65142, upload-time = "2026-07-13T19:39:32.147Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/31/3a4a4918856a0340e18a59e3743ebdc5682a07f0adeff3999bb9b417e9d0/modbus_connection-3.7.0-py3-none-any.whl", hash = "sha256:c977ce1973cc92dd1c6dee7b4cc35f3f424a8e322220a867b1f57987b2fdbd2e", size = 77058, upload-time = "2026-07-14T17:18:08.531Z" },
 ]
 
 [package.optional-dependencies]
@@ -349,7 +349,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "modbus-connection", extras = ["pymodbus"], specifier = ">=3.6.0" },
+    { name = "modbus-connection", extras = ["pymodbus"], specifier = ">=3.7.0" },
     { name = "pymodbus", specifier = ">=3.10.0,<4" },
 ]
 


### PR DESCRIPTION
Bumps `modbus-connection` from 3.6.0 to 3.7.0. The library's public API is unchanged, so no source changes are required for the migration itself.

### What we adopt

3.7.0 adds the mock's `fail_read`, which arms a read covering a given address to answer with an exception — mirroring a controller that refuses a register block it doesn't serve (e.g. an uninstalled module). This PR uses it to add a test proving that such a refusal surfaces as a `ModbusError` out of `async_update()` rather than silently leaving those fields at stale values. That's the behavior an integration relies on to mark the device unavailable, so it's worth pinning down.

### What we don't adopt (and why)

The rest of 3.7.0 targets device shapes this library isn't:

- **SunSpec model discovery / scan / generate** — Stiebel Eltron uses a fixed, manually-mapped register layout, not SunSpec.
- **Dynamically-scaled field writes, scale-factor registers in repeating blocks, nested register-count groups** — all our fields use static scale factors (0.1, 0.01) and fixed-count repeating groups, so there's nothing to wire up.
- **Converter logging by type name** — an internal improvement we get for free.

Verification: `pytest` (16 passed), `ruff check`, and `mypy` all pass on 3.7.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jHHmqB3gk9DPKJ7qCV7fz