### PR TITLE
Give the WPM 3i back the HK 1 setpoint it answers

### DIFF
--- a/api/wpm_system_values.csv
+++ b/api/wpm_system_values.csv
@@ -7,8 +7,8 @@ Modbus address,Object designation ,WPMsystem,WPM 3,WPM 3i,Comments,Min. value,Ma
 506,DEW POINT TEMPERATURE,,x,x,,-40,30,2,°C,r,
 507,OUTSIDE TEMPERATURE,x,x,x,,-60,80,2,°C,r,
 508,ACTUAL TEMPERATURE HK 1,x,x,x,,0,40,2,°C,r,
-509,SET TEMPERATURE HK 1,,,x,,0,65,2,°C,r,WPM3I
-510,SET TEMPERATURE HK 1,x,x,,,0,40,2,°C,r,
+509,SET TEMPERATURE HK 1,,,x,"Kept for the manual, but a WPM 3i leaves this unavailable and answers HK 1 on 510",0,65,2,°C,r,WPM3I
+510,SET TEMPERATURE HK 1,x,x,x,"A WPM 3i answers HK 1 here, not on 509, even though the manual lists it for WPMsystem and WPM 3 only",0,40,2,°C,r,
 511,ACTUAL TEMPERATURE HK 2,x,x,x,,0,90,2,°C,r,
 512,SET TEMPERATURE HK 2,x,x,x,,0,65,2,°C,r,
 513,ACTUAL FLOW TEMPERATURE WP,x,x,x,"MFG, if available",,,2,°C,r,

--- a/pystiebeleltron/wpm3i.py
+++ b/pystiebeleltron/wpm3i.py
@@ -24,6 +24,7 @@ class Wpm3iSystemValues(Component):
     outside_temperature = gauge(506, 0.1, nan=UNAVAILABLE, unit="°C")
     actual_temperature_hk_1 = gauge(507, 0.1, nan=UNAVAILABLE, unit="°C")
     set_temperature_hk_1_wpm3i = gauge(508, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_hk_1 = gauge(509, 0.1, nan=UNAVAILABLE, unit="°C")
     actual_temperature_hk_2 = gauge(510, 0.1, nan=UNAVAILABLE, unit="°C")
     set_temperature_hk_2 = gauge(511, 0.1, nan=UNAVAILABLE, unit="°C")
     actual_flow_temperature_wp = gauge(512, 0.1, nan=UNAVAILABLE, unit="°C")


### PR DESCRIPTION
## What

A WPM 3i answers `SET TEMPERATURE HK 1` on Modbus address **510**, not on **509**. The dedicated 3i map from #59 reads 509, so the setpoint never arrives. This adds 510 to the WPM 3i column and leaves 509 in place.

## Why it is a regression, not a long standing quirk

Before #59, a controller reporting model 391 was served by the WPM map, which reads 510, and that worked. A Tecalor TTC 05 Cool has **30196 hourly statistics rows for its HK 1 setpoint spanning 2023-02-11 to 2026-07-25**, between 5.0 and 44.3 °C. The series ends at the exact hour the 3i map went live on that machine, and the entity has been unavailable since.

## Evidence

Checked the way the manual asks for it, *"Vergleichen Sie den übermittelten Wert mit dem Anzeigewert auf dem Display des Reglers"*, read only over Modbus TCP on unit 1, next to that controller's own Servicewelt at the same moment:

| Servicewelt | Address | Field | Read |
|---|---|---|---|
| ISTTEMPERATUR HK 1 · 17.0 °C | 508 | `actual_temperature_hk_1` | 17.0 |
| SOLLTEMPERATUR HK 1 · 5.0 °C | 509 | (3i variant per manual) | `0x8000` |
| " | 510 | `set_temperature_hk_1` | **5.0** |

The 5.0 °C is frost protection while the machine cools, which is what the controller shows for HK 1 in that state, and it is the lower end of the historical series above. `0x8000` is the manual's own placeholder for an object a device does not have.

**This is not the one-based offset the manual warns about.** A shift would move the whole block; every neighbour matches the same screen exactly:

| Servicewelt | Address | Read |
|---|---|---|
| HEIZUNGSDRUCK 2.21 bar | 519 | 2.21 bar |
| ISTTEMPERATUR WW 54.5 / SOLL 55.0 °C | 521 / 522 | 54.5 / 55.0 |
| QUELLENDRUCK 0.92 bar | 537 | 0.92 bar |
| TAUPUNKTTEMPERATUR 12.7 °C | 506 | 12.7 |

**Two manual revisions say it, so the transcription is faithful.** `A 321798-44755-9770` lists 509 for WPM 3i only and 510 for WPMsystem and WPM 3. The newer `A 321798-47824-0146` (the one attached to #62) restructures the document into a WPMsystem section without model columns and a WPM 3 / WPM 3i section with two, and keeps the same assignment: 509 marked WPM 3i, 0 to 65; 510 marked WPM 3, 0 to 40. So the deviation belongs in the comment column rather than in a silently corrected table.

**The fix does not depend on why.** Two readings fit the measurement: either the model columns are wrong for this register, or this controller reports model 391 and behaves like a WPM 3 in this one place. Reading both addresses is correct either way, and since they sit in the same block read it costs nothing to not have to decide.

**The ISG firmware sides with the device.** Its own object database maps, for the `WPM_3_I` model, Modbus 30510 to Elster 471 `HKSOLLTEMP` and 30508 to Elster 714 `HKISTTEMP`, and carries **no object at all for 30509**. That address holds an object only for `WPM_IW` and `WPM_ME`, where it is Elster 4 `VORLAUFSOLLTEMP`, a flow setpoint, which also explains the wider 0 to 65 range the manual gives it.

## Why additive

509 keeps its WPM 3i mark, so `set_temperature_hk_1_wpm3i` stays exactly where it is and nobody on 0.6.1 gets an `AttributeError`. Both addresses sit in the same block read, so the extra field costs no traffic. Dropping the one that no WPM 3i answers is a separate call for you.

## Relation to #62

This complements #62 rather than working against it. That PR removes registers whose support across heat pumps is unclear, *"until we have better information on where it's supported"*. This one supplies that information for a single register, from a device, and corrects the model column instead of dropping the row. There is no file overlap and a test merge onto #62 is clean.

## Verification

- Generator rerun, so the CSV and `wpm3i.py` stay in sync
- `pytest` 16 passed, `ruff check` clean, `mypy` clean (the one `ruff format` finding is in `README.md` and pre-exists on `master`)
- Patched library read against the live controller: 17.0 actual, **5.0 setpoint**, 17.0 return, flow `None`, all matching the Servicewelt
- The Home Assistant integration's own guard suite, which resolves every entity accessor against every model API, passes against this branch and against #62
