### PR TITLE
Move the HK 3 input registers up by one address

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -3,7 +3,5 @@
 This folder contains the csv files which are describing the registers of the ISG modbus interface. The values in the cvs files are manually copied from the [Stiebel Eltron modbus documentation](https://www.stiebel-eltron.ch/content/dam/ste/ch/de/downloads/kundenservice/smart-home/Modbus/Modbus%20Bedienungsanleitung.pdf).
 The files can either be manually edited with your Code Editor (e.g. Visual Studio Code)  or edited with a spreadsheet editor like LibreOffice or Excel. The encoding of the files is UTF-8.
 
-Some entries deliberately deviate from the documentation, based on observed device behaviour. Where that is the case the Comments column says so, next to the row it applies to.
-
 The addresses here follow the documentation's one-based numbering. `scripts/generate.py` subtracts one from each of them for the zero-based PDU addresses the generated modules use. `mbpoll` is also one-based unless it is given `-0`, which switches it to zero-based PDU addressing, so it is worth establishing which convention a reported register number is in before comparing it against a row here.
 

--- a/api/README.md
+++ b/api/README.md
@@ -3,3 +3,7 @@
 This folder contains the csv files which are describing the registers of the ISG modbus interface. The values in the cvs files are manually copied from the [Stiebel Eltron modbus documentation](https://www.stiebel-eltron.ch/content/dam/ste/ch/de/downloads/kundenservice/smart-home/Modbus/Modbus%20Bedienungsanleitung.pdf).
 The files can either be manually edited with your Code Editor (e.g. Visual Studio Code)  or edited with a spreadsheet editor like LibreOffice or Excel. The encoding of the files is UTF-8.
 
+Some entries deliberately deviate from the documentation, based on observed device behaviour. Where that is the case the Comments column says so, next to the row it applies to.
+
+The addresses here follow the documentation's one-based numbering. `scripts/generate.py` subtracts one from each of them for the zero-based PDU addresses the generated modules use. `mbpoll` is also one-based unless it is given `-0`, which switches it to zero-based PDU addressing, so it is worth establishing which convention a reported register number is in before comparing it against a row here.
+

--- a/api/wpm_system_values.csv
+++ b/api/wpm_system_values.csv
@@ -107,5 +107,5 @@ Modbus address,Object designation ,WPMsystem,WPM 3,WPM 3i,Comments,Min. value,Ma
 606,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 3",,,2,°C,r,ROOM TEMP COOLING3
 607,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 4",,,2,°C,r,ROOM TEMP COOLING4
 608,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 5",,,2,°C,r,ROOM TEMP COOLING5
-609,ACTUAL TEMPERATURE HK 3,x,,,,0,90,2,°C,r,
-610,SET TEMPERATURE HK 3,x,,,,0,65,2,°C,r,
+610,ACTUAL TEMPERATURE HK 3,x,,,"The manual lists 609, but a WPMsystem answers the reading here and leaves 609 unavailable",0,90,2,°C,r,
+611,SET TEMPERATURE HK 3,x,,,"The manual lists 610, which carries the actual temperature; the setpoint sits one address higher",0,65,2,°C,r,

--- a/api/wpm_system_values.csv
+++ b/api/wpm_system_values.csv
@@ -107,5 +107,5 @@ Modbus address,Object designation ,WPMsystem,WPM 3,WPM 3i,Comments,Min. value,Ma
 606,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 3",,,2,°C,r,ROOM TEMP COOLING3
 607,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 4",,,2,°C,r,ROOM TEMP COOLING4
 608,SET TEMPERATURE,x,,,"Room temperature, cooling circuit 5",,,2,°C,r,ROOM TEMP COOLING5
-610,ACTUAL TEMPERATURE HK 3,x,,,"The manual lists 609, but a WPMsystem answers the reading here and leaves 609 unavailable",0,90,2,°C,r,
-611,SET TEMPERATURE HK 3,x,,,"The manual lists 610, which carries the actual temperature; the setpoint sits one address higher",0,65,2,°C,r,
+610,ACTUAL TEMPERATURE HK 3,x,,,"Documented as ISTTEMPERATUR HK 3 in manual revision A 321798-47824-0146; older revisions inspected ended the table at 608",0,90,2,°C,r,
+611,SET TEMPERATURE HK 3,x,,,"Documented as SOLLTEMPERATUR HK 3 in manual revision A 321798-47824-0146; older revisions inspected ended the table at 608",0,65,2,°C,r,

--- a/pystiebeleltron/wpm.py
+++ b/pystiebeleltron/wpm.py
@@ -9,7 +9,7 @@ from . import UNAVAILABLE, in_range, scaled_sum
 from ._components import ControllerComponents
 
 WPM_HOLDING_RANGES = ((1500, 1607), (1703, 1751), (4000, 4002), (4249, 4277))
-WPM_INPUT_RANGES = ((500, 609), (2500, 2572), (3500, 3642), (3643, 3733), (5000, 5001), (5219, 5230))
+WPM_INPUT_RANGES = ((500, 610), (2500, 2572), (3500, 3642), (3643, 3733), (5000, 5001), (5219, 5230))
 
 
 class WpmHeatPumpModule(Component):
@@ -90,8 +90,8 @@ class WpmSystemValues(Component):
     hot_gas_temperature = gauge(538, 0.1, nan=UNAVAILABLE, unit="°C")
     high_pressure = gauge(539, 0.1, nan=UNAVAILABLE, unit="bar")
     low_pressure = gauge(540, 0.1, nan=UNAVAILABLE, unit="bar")
-    actual_temperature_hk_3 = gauge(608, 0.1, nan=UNAVAILABLE, unit="°C")
-    set_temperature_hk_3 = gauge(609, 0.1, nan=UNAVAILABLE, unit="°C")
+    actual_temperature_hk_3 = gauge(609, 0.1, nan=UNAVAILABLE, unit="°C")
+    set_temperature_hk_3 = gauge(610, 0.1, nan=UNAVAILABLE, unit="°C")
     heat_pumps = repeating_group(6, WpmHeatPumpModule, stride=7)
     room_temperatures = repeating_group(5, WpmRoomTemperature, stride=4)
     room_temperatures_cooling = repeating_group(5, WpmRoomTemperatureCooling, stride=1)


### PR DESCRIPTION
The address change was originally proposed by @arturzielazny in
ThyMYthOS/python-stiebel-eltron#12, opened in December; their PR also contains
the HPA-O 13 mbpoll capture quoted below. This commit brings it to the current
generated API, and the newer official manual attached in the meantime now
documents the same two addresses.

[Manual revision A 321798-47824-0146](https://github.com/user-attachments/files/30384973/321798-47824-0146_ISG.Modbus_de_en_fr_it_nl_cs_sk_pl_hu.pdf),
dated June 2026 and attached by pail23 in ThyMYthOS/python-stiebel-eltron#62,
lists the input register references 610 ISTTEMPERATUR HK 3 and 611
SOLLTEMPERATUR HK 3 for the WPMsystem.

The CSV carried these rows at 609 and 610. Neither row appears at those
references in any manual revision inspected here; the older revisions checked
end this table at 608 and do not carry an HK 3 actual temperature or setpoint at
all. Where the CSV's 609 and 610 came from is not established by anything in
this PR. This commit moves both rows to the references the current revision
documents.

Numbering, because the same integers appear in both conventions below. The CSV
and the manual are one-based. `scripts/generate.py` subtracts one, so the
generated fields land on the zero-based wire addresses 609 and 610, up from 608
and 609.

Device observations. These do not decide the addresses on their own any more,
but they were the original reason for the change and they remain consistent with
the manual:

  - @arturzielazny's HPA-O 13 Premium:

        mbpoll -m tcp -a 1 -t 3:int16 -r 609 -c 4 -1 192.168.0.178
        [609]:  -32768
        [610]:  220
        [611]:  202
        [612]:  -32768

    mbpoll documents -0 as "First reference is 0 (PDU addressing) instead 1"
    and this command does not pass it, so the labels are one-based and directly
    comparable to the manual's references. At the documented 0.1 °C scale,
    references 610 and 611 hold 22.0 and 20.2 °C, while 609 holds -32768, the
    manual's sentinel for an object a device does not have. The capture places
    plausible temperatures exactly where the current manual puts the two fields.
    By itself it did not say which of the two is the reading and which is the
    setpoint; together with the manual naming 610 ISTTEMPERATUR and 611
    SOLLTEMPERATUR, the ordering is actual temperature first, setpoint second,
    which is the order this commit uses.

  - A WPMsystem behind an ISG Web, in pail23/stiebel_eltron_isg_component#560.
    The reporter observed the actual temperature entity unavailable while the
    setpoint entity read 26.0 °C and appeared to track the controller's
    ISTTEMPERATUR HK 3, with the Servicewelt showing SOLLTEMPERATUR 5.0 °C at the
    same moment. That is a UI observation rather than a Modbus capture. It is
    consistent with the old setpoint field reading the neighbouring actual
    temperature register, which is what a one-register offset would produce.

A third machine, a TECALOR WPMsystem reporting controller 449 with no HK 3
fitted, adds address level behaviour. Read only over Modbus TCP on unit 1, with
zero-based wire addresses:

    FC04 addr=608 count=1     ->  exception 2
    FC04 addr=609 count=1     ->  0x8000
    FC04 addr=610 count=1     ->  0x8000
    FC04 addr=611 count=1     ->  0x8000
    FC04 start=500 count=111  ->  ok

A one-register request at wire 608 is refused where the same request at 609, 610
and 611 is accepted. That is narrower than it looks. Exception 2 only says the
requested address was illegal for that request; it does not establish why, and
the 500..610 block covering wire 608 succeeds, so wire 608 is not unreadable in
every request shape. With no HK 3 fitted, the 0x8000 values at 609, 610 and 611
cannot identify either field. What this does establish is that the two wire
addresses this commit moves to are accepted, and that the extended 111-register
block is answered.

On the read range. WPM_INPUT_RANGES is derived from the CSV rows, so the
inclusive upper bound follows from regeneration on its own. It is not what makes
the setpoint get fetched: outside the declared ranges the planner gives it a
request of its own rather than dropping it. Against the generated plan, in wire
addresses:

    ranges (500, 610)   FC04 start=500 count=111
    ranges (500, 609)   FC04 start=500 count=110
                        FC04 start=610 count=1

That extra request is addr=610 count=1, which succeeded on the TECALOR above,
so nothing here suggests the split plan would fail on that machine. Keeping the
read contiguous avoids an additional request and therefore an additional
request-level failure opportunity, since a Modbus exception on any block raises
BlockReadError and fails the whole component update rather than one field. That
holds provided the controller accepts the longer block, which was verified only
on this TECALOR WPMsystem.

Evidence scope. WpmSystemValues serves WPMsystem, WPM 3 and LWZ_R290. The manual
revision documents these two references for the WPMsystem column, and both
machines here whose controller is known report WPMsystem; for the HPA-O 13 only
the product name is known, not the controller identifier. Nothing here has been
checked on a WPM 3 or an LWZ_R290.

Before this change the generated plan already covered wire 608 and 609 in its
500..609 block. The change extends that shared request through wire 610, from
110 to 111 registers. The WPM 3i map declares its own ranges ending at 540 and
does not carry these fields, so it is untouched. Public field names do not
change, so no caller-side rename is needed.

The patch changes two columns in the two CSV rows: the address and the Comments
cell, which now names the manual revision that documents them. Every schema and
metadata column is unchanged: object designation, the WPMsystem, WPM 3 and WPM
3i flags, min and max value, data type, unit, access and suffix all keep their
previous values. Regenerating with `scripts/generate.py` changes only
`pystiebeleltron/wpm.py`.

The second commit, on `api/README.md`, is not about these two rows. Other rows do
deliberately deviate from the manual on the strength of observed behaviour, 509
and 510 since e2b5749, and the README described the files as copied from the
documentation without qualification. Its second paragraph is the one-based
versus zero-based numbering, which is directly relevant here: every register
number in this PR comes either from a manual reference or from mbpoll output,
and both are one-based, while the generated modules are not.

GitHub CI is green on this branch. Locally, ruff check, mypy over
`pystiebeleltron` and the 23 tests pass.
