### PR TITLE
Cap modbus-connection below 4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<4"
 dependencies = [
-    "modbus-connection[pymodbus] (>=3.7.0)",
+    "modbus-connection[pymodbus] (>=3.7.0,<4)",
     "pymodbus (>=3.10.0,<4)",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -349,7 +349,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "modbus-connection", extras = ["pymodbus"], specifier = ">=3.7.0" },
+    { name = "modbus-connection", extras = ["pymodbus"], specifier = ">=3.7.0,<4" },
     { name = "pymodbus", specifier = ">=3.10.0,<4" },
 ]
 


### PR DESCRIPTION
The current modbus-connection dependency is only bounded from below (`>=3.7.0`). Now that 4.0.0 is published, a clean resolution can select a major version this release line was not declared against. This adds an upper bound of `<4`, matching the cap already used for pymodbus.

The lockfile only changes in the `requires-dist` metadata; the locked version stays at the minimum 3.7.0, so CI keeps testing against the oldest supported release.

Verified: `uv lock --check` passes, and the test suite passes with 3.7.0 on Python 3.12, 3.13 and 3.14, plus a separate Python 3.14 run against the latest allowed 3.9.0. Ruff and mypy are clean.

No package version bump is included.
