### PR TITLE
Split reads

### DIFF
--- a/pystiebeleltron/lwz.py
+++ b/pystiebeleltron/lwz.py
@@ -10,8 +10,8 @@ from modbus_connection.model import Component, boolean, gauge, integer
 from . import UNAVAILABLE, in_range, scaled_sum
 from ._components import ControllerComponents
 
-LWZ_HOLDING_RANGES = ((1000, 1026), (4000, 4002), (4249, 4277))
-LWZ_INPUT_RANGES = ((0, 33), (2000, 2004), (3000, 3031), (3679, 3697), (5000, 5001), (5219, 5230))
+LWZ_HOLDING_RANGES = ((1000, 1026), (4000, 4002), (4249, 4251), (4253, 4258), (4271, 4277))
+LWZ_INPUT_RANGES = ((0, 33), (2000, 2004), (3000, 3031), (3679, 3679), (3689, 3697), (5000, 5001), (5219, 5221), (5229, 5230))
 
 
 class OperatingMode(Enum):

--- a/pystiebeleltron/wpm.py
+++ b/pystiebeleltron/wpm.py
@@ -8,8 +8,8 @@ from modbus_connection.model import Component, boolean, gauge, integer, repeatin
 from . import UNAVAILABLE, in_range, scaled_sum
 from ._components import ControllerComponents
 
-WPM_HOLDING_RANGES = ((1500, 1607), (1703, 1751), (4000, 4002), (4249, 4277))
-WPM_INPUT_RANGES = ((500, 610), (2500, 2572), (3500, 3733), (5000, 5001), (5219, 5230))
+WPM_HOLDING_RANGES = ((1500, 1520), (1550, 1558), (1603, 1607), (1703, 1708), (1749, 1751), (4000, 4002), (4249, 4251), (4253, 4255), (4257, 4258), (4271, 4277))
+WPM_INPUT_RANGES = ((500, 607), (609, 610), (2500, 2546), (2560, 2565), (2569, 2572), (3500, 3654), (3679, 3684), (3689, 3733), (5000, 5001), (5219, 5221), (5229, 5230))
 
 
 class WpmHeatPumpModule(Component):

--- a/pystiebeleltron/wpm3i.py
+++ b/pystiebeleltron/wpm3i.py
@@ -9,7 +9,7 @@ from . import UNAVAILABLE, in_range, scaled_sum
 from ._components import ControllerComponents
 
 WPM3I_HOLDING_RANGES = ((1500, 1520), (4000, 4002))
-WPM3I_INPUT_RANGES = ((500, 540), (2500, 2506), (3500, 3521), (5000, 5001))
+WPM3I_INPUT_RANGES = ((500, 526), (532, 533), (535, 540), (2500, 2501), (2503, 2504), (2506, 2506), (3500, 3521), (5000, 5001))
 
 
 class Wpm3iSystemValues(Component):

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -382,10 +382,7 @@ def _ranges_by_space(components: list[Component]) -> dict[str, tuple[tuple[int, 
     addresses: dict[str, set[int]] = {}
     for component in components:
         addresses.setdefault(component.register_space, set()).update(component.addresses)
-    return {
-        space: _coalesce({(address, address) for address in space_addresses})
-        for space, space_addresses in addresses.items()
-    }
+    return {space: _coalesce({(address, address) for address in space_addresses}) for space, space_addresses in addresses.items()}
 
 
 def _imports(controller: Controller, components: list[Component]) -> list[str]:

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -220,6 +220,7 @@ class Component:
     ranges_const: str = ""
     low: int = 0  # first wire address the block covers
     high: int = 0  # last wire address the block covers
+    addresses: set[int] = field(default_factory=set)  # wire addresses defined by the CSV rows
     fields: list[str] = field(default_factory=list)  # "attr = factory(...)"
     repeats: list[str] = field(default_factory=list)  # "attr = repeating_group(...)"
     compressor_starts: bool = False
@@ -236,6 +237,11 @@ def _span(rows: list[list[str]]) -> tuple[int, int]:
     """The block's (low, high) wire address range, covering every row read."""
     addresses = [int(row[0]) - 1 for row in rows]
     return min(addresses), max(addresses)
+
+
+def _addresses(rows: list[list[str]]) -> set[int]:
+    """Return the wire addresses represented by CSV rows, including repeats."""
+    return {int(row[0]) - 1 for row in rows}
 
 
 def _match_repeat(suffix: str, repeats: list[Repeat]) -> tuple[Repeat, int] | None:
@@ -283,6 +289,7 @@ def _plain_component(block: Block, rows: list[list[str]], controller: Controller
         block.space,
         low=low,
         high=high,
+        addresses=_addresses(rows),
     )
     groups: dict[str, dict[int, list[list[str]]]] = {repeat.attr: {} for repeat in block.repeats}
     seen: set[str] = set()
@@ -319,6 +326,7 @@ def _energy_component(block: Block, rows: list[list[str]], controller: Controlle
         block.space,
         low=low,
         high=high,
+        addresses=_addresses(rows),
     )
     seen: set[str] = set()
 
@@ -370,11 +378,14 @@ def _coalesce(spans: set[tuple[int, int]]) -> tuple[tuple[int, int], ...]:
 
 
 def _ranges_by_space(components: list[Component]) -> dict[str, tuple[tuple[int, int], ...]]:
-    """The device-wide readable ranges per space (block spans plus the shared blocks)."""
-    spans: dict[str, set[tuple[int, int]]] = {}
+    """The device-wide readable ranges per space, split at unmapped addresses."""
+    addresses: dict[str, set[int]] = {}
     for component in components:
-        spans.setdefault(component.register_space, set()).add((component.low, component.high))
-    return {space: _coalesce(ranges) for space, ranges in spans.items()}
+        addresses.setdefault(component.register_space, set()).update(component.addresses)
+    return {
+        space: _coalesce({(address, address) for address in space_addresses})
+        for space, space_addresses in addresses.items()
+    }
 
 
 def _imports(controller: Controller, components: list[Component]) -> list[str]:

--- a/test/test_stiebel_eltron.py
+++ b/test/test_stiebel_eltron.py
@@ -364,7 +364,7 @@ async def test_a_busy_controller_does_not_lose_an_optional_block(mock_modbus_uni
     # rather than as something the tolerance rewrapped on the way out.
     with pytest.raises(ServerDeviceBusyError) as exc_info:
         await api.async_update()
-    assert exc_info.value.block == ReadBlock("input", 5219, 12)
+    assert exc_info.value.block == ReadBlock("input", 5219, 3)
 
     mock_modbus_unit.fail_read(5219, None, register_type="input")
     await api.async_update()


### PR DESCRIPTION
According to stiebel eltron, in future reading registers which are not defined will fail. This change splits the big block reads in multiple smaller reads to avoid reading the registers which are not available.